### PR TITLE
feat(plugin): options

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -3,7 +3,8 @@
  * @module vite-plugin-react-docgen-typescript/Options
  */
 
-import type { ParserOptions } from 'react-docgen-typescript'
+import type { ComponentDoc, ParserOptions } from 'react-docgen-typescript'
+import type { Plugin } from 'vite'
 
 /**
  * Vite `react-docgen-typescript` plugin options.
@@ -12,6 +13,86 @@ import type { ParserOptions } from 'react-docgen-typescript'
  *
  * @extends {ParserOptions}
  */
-interface Options extends ParserOptions {}
+interface Options extends ParserOptions {
+  /**
+   * Apply plugin only during serve or build, or on certain conditions.
+   *
+   * @see https://vitejs.dev/guide/api-plugin.html#conditional-application
+   */
+  apply?: Plugin['apply']
+
+  /**
+   * Plugin ordering.
+   *
+   * @see https://vitejs.dev/guide/api-plugin.html#plugin-ordering
+   *
+   * @default 'pre'
+   */
+  enforce?: Plugin['enforce']
+
+  /**
+   * Glob patterns matching files to exclude from parsing.
+   *
+   * **Note**: Applied **after** {@link include}.
+   *
+   * @see https://github.com/micromatch/micromatch
+   *
+   * @default []
+   */
+  exclude?: string[]
+
+  /**
+   * Apply additional processing to a `ComponentDoc` before `__docgenInfo` is
+   * declared and assigned a value.
+   *
+   * **Note**: `code` may have transforms from other plugins already applied.
+   *
+   * @see {@link ComponentDoc}
+   *
+   * @param {ComponentDoc} doc - Component docgen info object
+   * @param {string} code - Module code being transformed
+   * @param {string} id - Path to module being transformed
+   * @return {ComponentDoc | Promise<ComponentDoc>} Augmented `doc`
+   *
+   * @default doc=>doc
+   */
+  handler?(
+    doc: ComponentDoc,
+    code: string,
+    id: string
+  ): ComponentDoc | Promise<ComponentDoc>
+
+  /**
+   * Glob patterns matching files to parse for docgen information.
+   *
+   * @see https://github.com/micromatch/micromatch
+   *
+   * @default ['**.tsx']
+   */
+  include?: string[]
+
+  /**
+   * Generate the name of the component to add a `__docgenInfo` property to.
+   *
+   * **Note**: `code` may have transforms from other plugins already applied.
+   *
+   * @see {@link ComponentDoc}
+   *
+   * @param {ComponentDoc} doc - Component docgen info object
+   * @param {string} code - Module code being transformed
+   * @param {string} id - Path to module being transformed
+   * @return {Promise<string> | string} Component name
+   *
+   * @default doc=>doc.displayName
+   */
+  name?(doc: ComponentDoc, code: string, id: string): Promise<string> | string
+
+  /**
+   * Name of tsconfig file or path to tsconfig file.
+   *
+   * @default path.resolve('tsconfig.json')
+   */
+  tsconfig?: string
+}
 
 export type { Options as default }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

Implemented plugin options as a TypeScript interface.

The options interface extends [`ParserOptions`][1] and adds several plugin specific options:

- `apply?`: [Conditional application][2]
- `enforce?`:  [Plugin ordering][3]
- `exclude?`: Glob patterns matching files to exclude from parsing. Applied after `include`
- `handler?`: Apply additional processing to a [`ComponentDoc`][4] before `__docgenInfo` is declared + assigned a value
- `include?`: Glob patterns matching files to parse for docgen information
- `name?`: Generate the name of the component to add a `__docgenInfo` property to
- `tsconfig?`: Name of tsconfig file or path to tsconfig file

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

N/A

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

- Docs for `exclude` and `include` reference [`micromatch`][5]

    > Vite exposes [@rollup/pluginutils's `createFilter`][6] function to encourage Vite specific plugins and integrations to use the standard include/exclude filtering pattern, which is also used in Vite core itself.

    \- [Filtering, include/exclude pattern][7], Vite Plugin API

     `createFilter` uses [`picomatch`][8] under the hood. Unlike `micromatch`, **[`picomatch` does not support brace expansion][9]**.  For now, `micromatch` will be used. This topic will be revisited in #2, however.

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

closes #1

## Submission checklist

- [x] pr title prefixed with `PR:` (e.g: `PR: User authentication`)
- [x] pr title describes functionality (not vague title like `Update index.md`)
- [x] pr targets branch `next`
- [x] project was run locally to verify that there are no errors
- [x] documentation added or updated

[1]: https://github.com/styleguidist/react-docgen-typescript/blob/v2.2.2/src/parser.ts#L83
[2]: https://vitejs.dev/guide/api-plugin.html#conditional-application
[3]: https://vitejs.dev/guide/api-plugin.html#plugin-ordering
[4]: https://github.com/styleguidist/react-docgen-typescript/blob/v2.2.2/src/parser.ts#L16
[5]: https://github.com/micromatch/micromatch
[6]: https://github.com/rollup/plugins/tree/pluginutils-v4.2.1/packages/pluginutils#createfilter
[7]: https://vitejs.dev/guide/api-plugin.html#filtering-include-exclude-pattern
[8]: https://github.com/micromatch/picomatch
[9]: https://github.com/micromatch/picomatch/tree/2.3.1#library-comparisons
