### PR TITLE
feat(plugin): docgen parsing

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,6 +13,7 @@
   "failFast": false,
   "flagWords": [],
   "ignorePaths": [
+    "**/*.snap",
     "**/.gitignore",
     ".cspell.json",
     ".env*",

--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -17,9 +17,11 @@ esbenp
 esbuild
 fbca
 fpnv
+frec
 gifv
 gpgsign
 iife
+jsxdev
 lcov
 lintstagedrc
 micnncim
@@ -32,9 +34,11 @@ nums
 nvmrc
 ohmyzsh
 pdel
+picomatch
 rcmdnk
 safecrlf
 syncer
+telejson
 tsnode
 tspaths
 vates

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@
 
 # DIRECTORIES & FILES
 **/.DS_Store
+**/*.snap
 .eslintcache
 .yarn/*
 CHANGELOG.md

--- a/.eslintrc.base.cjs
+++ b/.eslintrc.base.cjs
@@ -53,11 +53,24 @@ const config = {
     node: true
   },
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
-  globals: {},
+  globals: {
+    Chai: 'readonly',
+    Console: 'readonly',
+    JSX: 'readonly',
+    LoadHook: 'readonly',
+    LoadHookContext: 'readonly',
+    LoadHookResult: 'readonly',
+    LoaderHookFormat: 'readonly',
+    NodeJS: 'readonly',
+    ResolveFilename: 'readonly',
+    ResolveHook: 'readonly',
+    ResolveHookContext: 'readonly',
+    ResolveHookResult: 'readonly'
+  },
   parser: require.resolve('@typescript-eslint/parser'),
   parserOptions: {
     ecmaFeatures: {
-      jsx: Boolean(tsconfig.compilerOptions.jsx ?? false),
+      jsx: Boolean(tsconfig.compilerOptions.jsx),
       impliedStrict: true
     },
     emitDecoratorMetadata: tsconfig.compilerOptions.emitDecoratorMetadata,
@@ -518,7 +531,7 @@ const config = {
     'jsdoc/check-tag-names': [
       1,
       {
-        definedTags: ['fixme', 'link', 'maximum', 'minimum'],
+        definedTags: ['visibleName'],
         jsxTags: true
       }
     ],
@@ -543,27 +556,7 @@ const config = {
     ],
     'jsdoc/no-restricted-syntax': 0,
     'jsdoc/no-types': 0,
-    'jsdoc/no-undefined-types': [
-      1,
-      {
-        definedTypes: [
-          'Chai',
-          'Console',
-          'JSX',
-          'LoadHook',
-          'LoadHookContext',
-          'LoadHookResult',
-          'LoaderHookFormat',
-          'NodeJS',
-          'ResolveFilename',
-          'ResolveHook',
-          'ResolveHookContext',
-          'ResolveHookResult',
-          'never',
-          'unknown'
-        ]
-      }
-    ],
+    'jsdoc/no-undefined-types': [1, { definedTypes: ['never', 'unknown'] }],
     'jsdoc/require-asterisk-prefix': [1, 'always'],
     'jsdoc/require-description-complete-sentence': 0,
     'jsdoc/require-description': [
@@ -908,6 +901,7 @@ const config = {
         '@typescript-eslint/no-base-to-string': 0,
         '@typescript-eslint/no-unused-expressions': 0,
         '@typescript-eslint/restrict-template-expressions': 0,
+        '@typescript-eslint/unbound-method': 0,
         'chai-expect/missing-assertion': 2,
         'chai-expect/no-inner-compare': 2,
         'chai-expect/no-inner-literal': 2,
@@ -1233,8 +1227,15 @@ const config = {
           name: 'namepath-defining',
           required: ['type']
         },
+        type: {
+          name: 'namepath-defining',
+          required: ['type']
+        },
         var: {
           name: 'namepath-defining',
+          required: ['name']
+        },
+        visibleName: {
           required: ['name']
         },
         yield: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,12 @@ const config = {
   overrides: [
     ...base.overrides,
     {
+      files: ['__fixtures__/**'],
+      rules: {
+        'unicorn/filename-case': 0
+      }
+    },
+    {
       files: ['build.config.ts'],
       rules: {
         'unicorn/prefer-module': 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
       separator: '-'
     rebase-strategy: auto
     target-branch: next
-    versioning-strategy: increase
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -29,7 +28,10 @@ updates:
       prefix: build
       include: scope
     ignore:
+      - dependency-name: '@storybook/react'
       - dependency-name: '@types/node'
+      - dependency-name: '@types/styled-components'
+      - dependency-name: styled-components
     labels:
       - type:build
     open-pull-requests-limit: 5

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -6,4 +6,4 @@
 #
 # - https://vitest.dev/guide/cli.html#changed
 
-yarn test --changed
+yarn test --changed HEAD^

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@
 # DIRECTORIES & FILES
 **/.gitignore
 **/.gitkeep
+**/*.snap
 .eslintcache
 .eslintignore
 .husky/_/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,12 @@
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[jest-snapshot]": {
+    "editor.rulers": [120],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 120,
+    "rewrap.wrappingColumn": 120
+  },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
@@ -39,6 +45,7 @@
     "typescriptreact"
   ],
   "files.associations": {
+    "*.snap": "jest-snapshot",
     ".env.zsh": "shellscript",
     ".markdownlintignore": "ignore",
     "commit-msg": "shellscript",
@@ -80,6 +87,11 @@
       "icon": "tsconfig"
     },
     {
+      "extensions": ["snap"],
+      "format": "svg",
+      "icon": "vitest"
+    },
+    {
       "extensions": ["yarnrc.yml"],
       "format": "svg",
       "icon": "yarn"
@@ -90,6 +102,11 @@
       "extensions": ["__fixtures__"],
       "format": "svg",
       "icon": "data"
+    },
+    {
+      "extensions": ["__snapshots__"],
+      "format": "svg",
+      "icon": "temp"
     },
     {
       "extensions": ["setup"],

--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ npmScopes:
 
 ## Built With
 
-- [magic-string][1]
-- [micromatch][2]
+- [@rollup/pluginutils][1]
+- [magic-string][2]
 - [react-docgen-typescript][3]
-- [ts-dedent][4]
+- [telejson][4]
 
-[1]: https://github.com/Rich-Harris/magic-string
-[2]: https://github.com/micromatch/micromatch
+[1]: https://github.com/rollup/plugins/tree/master/packages/pluginutils
+[2]: https://github.com/Rich-Harris/magic-string
 [3]: https://github.com/styleguidist/react-docgen-typescript
-[4]: https://github.com/tamino-martinius/node-ts-dedent
+[4]: https://github.com/storybookjs/telejson
 [5]: https://vitejs.dev
 [6]:
   https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries

--- a/__fixtures__/Button.stories.tsx
+++ b/__fixtures__/Button.stories.tsx
@@ -1,0 +1,20 @@
+/**
+ * @file Fixtures - Button Stories
+ * @module fixtures/Button.stories
+ */
+
+import type { Meta, Story } from '@storybook/react'
+import Button, { CounterButton, type CounterButtonProps } from './Button'
+
+export default {
+  args: Button.defaultProps,
+  component: Button,
+  parameters: {},
+  title: 'Button'
+} as Meta<CounterButtonProps>
+
+export const Counter: Story<CounterButtonProps> = (
+  args: CounterButtonProps
+) => {
+  return <CounterButton {...args} />
+}

--- a/__fixtures__/Button.tsx
+++ b/__fixtures__/Button.tsx
@@ -1,0 +1,113 @@
+/**
+ * @file Fixtures - Button
+ * @module fixtures/Button
+ */
+
+import {
+  forwardRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type ForwardedRef
+} from 'react'
+import s, { css } from 'styled-components'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * Button background color.
+   *
+   * @default 'black'
+   */
+  $bg?: ButtonHTMLAttributes<HTMLButtonElement>['color']
+
+  /**
+   * Button text color.
+   *
+   * @default 'white'
+   */
+  $color?: ButtonHTMLAttributes<HTMLButtonElement>['color']
+
+  /**
+   * Button font size.
+   *
+   * @default '1.25rem'
+   */
+  $fontsize?: number | string
+
+  /**
+   * Mark button as disabled.
+   */
+  disabled?: boolean
+}
+
+interface CounterButtonProps extends ButtonProps {
+  /**
+   * Initial click count.
+   *
+   * @default 0
+   */
+  count?: number
+}
+
+/**
+ * Renders an HTML `<button>` element.
+ *
+ * @see https://developer.mozilla.org/docs/Web/HTML/Element/button
+ * @see https://developer.mozilla.org/docs/Web/API/HTMLButtonElement
+ *
+ * @visibleName Button
+ */
+const Button = s.button.attrs<ButtonProps>(p => ({
+  'aria-disabled': p.disabled ?? undefined,
+  'aria-hidden': p.hidden ?? undefined
+}))<ButtonProps>(p => {
+  return css`
+    background-color: ${p.$bg};
+    color: ${p.$color};
+  `
+})
+
+Button.defaultProps = {
+  $bg: 'black',
+  $color: 'white',
+  $fontsize: '1.25rem',
+  type: 'button'
+}
+
+/**
+ * Renders a button that displays how many times it has been clicked.
+ *
+ * @param {CounterButtonProps} [props={}] - Component props
+ * @param {ForwardedRef<HTMLButtonElement>} [ref] - `<button>` reference
+ * @return {JSX.Element} Counter button markup
+ */
+const CounterButton = forwardRef(function (
+  props: CounterButtonProps = {},
+  ref?: ForwardedRef<HTMLButtonElement>
+): JSX.Element {
+  const { count, ...rest } = props
+
+  const [clicks, setclicks] = useState<number>(count!)
+
+  /**
+   * Increases {@link clicks}.
+   *
+   * @return {void} Nothing when complete
+   */
+  const increment = (): void => setclicks(prev => prev + 1)
+
+  return (
+    <Button {...rest} onClick={increment} ref={ref}>
+      {clicks}
+    </Button>
+  )
+})
+
+CounterButton.displayName = 'CounterButton'
+CounterButton.defaultProps = {}
+
+export {
+  Button as default,
+  CounterButton,
+  type ButtonProps,
+  type CounterButtonProps
+}

--- a/__fixtures__/Counter.tsx
+++ b/__fixtures__/Counter.tsx
@@ -1,0 +1,61 @@
+/**
+ * @file Fixtures - Counter
+ * @module fixtures/Counter
+ */
+
+import { useState, type FC } from 'react'
+
+/**
+ * Renders a basic counter.
+ *
+ * @see https://dev.to/estheragbaje/how-to-use-react-hooks-to-create-a-counter-component-1bmp
+ *
+ * @return {JSX.Element} JSX element
+ */
+function Counter(): JSX.Element {
+  const [count, setcount] = useState(0)
+
+  /**
+   * Decreases {@link count}.
+   *
+   * @return {void} Nothing when complete
+   */
+  const decrement = (): void => setcount(prev => prev - 1)
+
+  /**
+   * Increases {@link count}.
+   *
+   * @return {void} Nothing when complete
+   */
+  const increment = (): void => setcount(prev => prev + 1)
+
+  return (
+    <div style={{ margin: '0 auto', width: '100%' }}>
+      <h4 style={{ marginBlock: '1.5rem', textAlign: 'center' }}>
+        Count is {count}
+      </h4>
+      <div
+        style={{
+          alignContent: 'center',
+          display: 'flex',
+          justifyContent: 'center'
+        }}
+      >
+        <button onClick={decrement} style={{ padding: '.75rem 1.25rem' }}>
+          -
+        </button>
+        <button onClick={increment} style={{ padding: '.75rem 1.25rem' }}>
+          +
+        </button>
+        <button
+          onClick={() => setcount(0)}
+          style={{ padding: '.75rem 1.25rem' }}
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default Counter as FC

--- a/__fixtures__/List.tsx
+++ b/__fixtures__/List.tsx
@@ -1,0 +1,59 @@
+/**
+ * @file Fixtures - List
+ * @module fixtures/List
+ */
+
+import type { LiHTMLAttributes, OlHTMLAttributes, Ref } from 'react'
+import s, { css } from 'styled-components'
+
+interface ListProps<
+  T extends HTMLOListElement | HTMLUListElement =
+    | HTMLOListElement
+    | HTMLUListElement
+> extends OlHTMLAttributes<T> {
+  /**
+   * List items to render.
+   *
+   * @default []
+   */
+  $items?: LiHTMLAttributes<HTMLLIElement>[]
+
+  /**
+   * Type of list to render.
+   *
+   * @default 'ul'
+   */
+  as?: 'ol' | 'ul'
+
+  /**
+   * Reference to inner list element.
+   */
+  ref?: Ref<T>
+}
+
+/**
+ * Renders an HTML `<ol>` or `<ul>` element.
+ *
+ * Pass `props.as` to change the list type.
+ *
+ * @see https://developer.mozilla.org/docs/Web/HTML/Element/ol
+ * @see https://developer.mozilla.org/docs/Web/HTML/Element/ul
+ * @see https://developer.mozilla.org/docs/Web/API/HTMLOListElement
+ * @see https://developer.mozilla.org/docs/Web/API/HTMLUListElement
+ */
+const List = s.ul.attrs<ListProps>(p => ({
+  'aria-hidden': p.hidden ?? undefined,
+  children: (() => {
+    if (!p.$items || p.$items.length === 0) return p.children
+    return p.$items.map((item, i) => <li {...item} key={i} />)
+  })()
+}))<ListProps>(() => css``)
+
+List.displayName = 'List'
+List.defaultProps = {
+  $items: [],
+  as: 'ul'
+}
+
+export default List
+export { type ListProps }

--- a/__fixtures__/empty.tsx
+++ b/__fixtures__/empty.tsx
@@ -1,0 +1,6 @@
+/**
+ * @file Fixtures - Empty File
+ * @module fixtures/empty
+ */
+
+export {}

--- a/__fixtures__/transform-plugin-context.ts
+++ b/__fixtures__/transform-plugin-context.ts
@@ -1,0 +1,54 @@
+/**
+ * @file Fixtures - TransformPluginContext
+ * @module fixtures/TransformPluginContext
+ */
+
+import type { TransformPluginContext } from 'rollup'
+import { VERSION as rollupVersion } from 'rollup'
+
+/**
+ * Mock transform plugin context.
+ *
+ * @const {TransformPluginContext} context
+ */
+const context: TransformPluginContext = {
+  addWatchFile: vi.fn(),
+  cache: {
+    delete: vi.fn().mockReturnValue(true),
+    get: vi.fn(),
+    has: vi.fn().mockReturnValue([false, true][Math.floor(Math.random() * 2)]),
+    set: vi.fn()
+  },
+  emitAsset: vi.fn(),
+  emitChunk: vi.fn(),
+  emitFile: vi.fn(),
+  error: vi.fn(),
+  getAssetFileName: vi.fn(),
+  getChunkFileName: vi.fn(),
+  getCombinedSourcemap: vi.fn(),
+  getFileName: vi.fn(),
+  getModuleIds: vi.fn().mockReturnValue(
+    (function* ids(): IterableIterator<string> {
+      yield faker.datatype.uuid()
+      yield faker.datatype.uuid()
+      yield faker.datatype.uuid()
+    })()
+  ),
+  getModuleInfo: vi.fn(),
+  getWatchFiles: vi.fn().mockReturnValue([]),
+  isExternal: vi.fn(),
+  load: vi.fn(),
+  meta: { rollupVersion, watchMode: false },
+  moduleIds: (function* ids(): IterableIterator<string> {
+    yield faker.datatype.uuid()
+    yield faker.datatype.uuid()
+    yield faker.datatype.uuid()
+  })(),
+  parse: vi.fn(),
+  resolve: vi.fn().mockResolvedValue(null),
+  resolveId: vi.fn().mockResolvedValue(null),
+  setAssetSource: vi.fn(),
+  warn: vi.fn()
+}
+
+export default context

--- a/build.config.ts
+++ b/build.config.ts
@@ -4,6 +4,7 @@
  * @see https://github.com/unjs/unbuild#configuration
  */
 
+import type { MkdistOptions } from 'mkdist'
 import path from 'node:path'
 import { applyChanges } from 'resolve-tspaths/dist/steps/applyChanges'
 import { computeAliases } from 'resolve-tspaths/dist/steps/computeAliases'
@@ -15,7 +16,8 @@ import {
   defineBuildConfig,
   type BuildConfig,
   type BuildContext,
-  type BuildOptions
+  type BuildOptions,
+  type MkdistBuildEntry
 } from 'unbuild'
 
 /** @const {BuildConfig} config - Build config */
@@ -71,6 +73,19 @@ const config: BuildConfig = defineBuildConfig({
       } catch (e: unknown) {
         console.error(e instanceof Error ? e.message : e)
       }
+    },
+    /**
+     * Updates `mkdist` build options.
+     *
+     * @see https://github.com/unjs/mkdist#-usage
+     *
+     * @param {BuildContext} _ - Build context
+     * @param {MkdistBuildEntry} __ - `mkdist` build entry
+     * @param {MkdistOptions} options - `mkdist` build options
+     * @return {void} Nothing when complete
+     */
+    'mkdist:entry:options'(_, __, options: MkdistOptions): void {
+      options.pattern = '*'
     }
   }
 })

--- a/loader.mjs
+++ b/loader.mjs
@@ -26,7 +26,7 @@ const hooks = createEsmHooks(register())
  *
  * @param {string} url - `file:` url of module
  * @param {LoadHookContext} context - Hook context
- * @param {(LoaderHookFormat | null)?} [context.format] - Module format
+ * @param {?LoaderHookFormat} [context.format] - Module format
  * @param {ImportAssertions} context.importAssertions - Import assertions map
  * @param {LoadHook} defaultLoad - Default Node.js `load` function
  * @return {Promise<LoadHookResult>} Hook result

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "type": "module",
   "files": [
     "dist",
-    "src",
+    "src/*",
     "CHANGELOG.md"
   ],
   "exports": {
@@ -60,7 +60,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "unbuild",
-    "check:ci": "yarn fix:cg && yarn check:spelling && yarn check:types && yarn test && NODE_ENV=production yarn pack -o %s-%v.tgz",
+    "check:ci": "yarn fix:cg && yarn check:spelling && yarn check:types && yarn test && NODE_ENV=production yarn pack -o %s-%v.tgz && yarn clean:pack",
     "check:dedupe": "yarn dedupe --check",
     "check:format": "prettier --check .",
     "check:lint": "eslint --cache --exit-on-fatal-error --ext cjs,json,md,mjs,ts,tsx,yml --max-warnings 0 .",
@@ -69,6 +69,7 @@
     "check:upgrades": "yarn upgrade-interactive",
     "clean:build": "trash ./{dist,*.tgz}",
     "clean:modules": "trash ./.yarn/{cache,*.gz} ./node_modules",
+    "clean:pack": "trash ./*.tgz",
     "clean:test": "trash ./coverage",
     "fix:cg": "yarn fix:format && yarn fix:lint",
     "fix:dedupe": "yarn dedupe --strategy=highest",
@@ -85,11 +86,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@types/micromatch": "4.0.2",
+    "@rollup/pluginutils": "4.2.1",
     "magic-string": "0.26.2",
-    "micromatch": "4.0.5",
     "react-docgen-typescript": "2.2.2",
-    "ts-dedent": "2.2.0"
+    "telejson": "6.0.8"
   },
   "devDependencies": {
     "@commitlint/cli": "17.0.3",
@@ -97,19 +97,21 @@
     "@commitlint/types": "17.0.0",
     "@faker-js/faker": "7.3.0",
     "@flex-development/tutils": "4.8.0",
+    "@storybook/react": "6.5.9",
     "@types/chai": "4.3.1",
     "@types/eslint": "8.4.5",
     "@types/is-ci": "3.0.0",
-    "@types/micromatch": "4.0.2",
     "@types/mvdan-sh": "0.5.1",
     "@types/node": "16.11.45",
     "@types/node-notifier": "8.0.2",
     "@types/prettier": "2.6.3",
     "@types/react": "18.0.15",
+    "@types/styled-components": "5.1.25",
     "@typescript-eslint/eslint-plugin": "5.31.0",
     "@typescript-eslint/parser": "5.31.0",
     "@vates/toggle-scripts": "1.0.0",
     "@vitest/ui": "0.19.1",
+    "c8": "7.12.0",
     "chai": "4.3.6",
     "cspell": "6.4.1",
     "eslint": "8.20.0",
@@ -137,7 +139,9 @@
     "pretty-format": "28.1.3",
     "react": "18.2.0",
     "resolve-tspaths": "0.7.1",
+    "styled-components": "5.3.5",
     "trash-cli": "5.0.0",
+    "ts-dedent": "2.2.0",
     "ts-node": "10.9.1",
     "tsconfig": "7.0.0",
     "tsconfig-paths": "4.0.0",
@@ -145,7 +149,6 @@
     "vite": "3.0.3",
     "vite-plugin-inspect": "0.6.0",
     "vite-tsconfig-paths": "3.5.0",
-    "viteshot": "0.3.1",
     "vitest": "0.19.1",
     "vitest-github-actions-reporter": "0.8.1",
     "yaml-eslint-parser": "1.0.1"
@@ -154,10 +157,9 @@
     "vite": ">=2.0.0"
   },
   "resolutions": {
-    "c8": "7.12.0",
-    "consola": "2.15.3",
+    "@types/picomatch": "2.3.0",
     "mkdist": "patch:mkdist@npm:0.3.13#.yarn/patches/mkdist-npm-0.3.13-c41cf41c68.patch",
-    "simple-git": "3.10.0",
+    "picomatch": "2.3.1",
     "typescript": "4.8.0-beta"
   },
   "engines": {

--- a/src/__snapshots__/plugin.functional.snap
+++ b/src/__snapshots__/plugin.functional.snap
@@ -1,0 +1,126 @@
+// Vitest Snapshot v1
+
+exports[`functional:plugin > should not transform module if docgen info is missing 1`] = `null`;
+
+exports[`functional:plugin > should not transform module if id does not match include pattern 1`] = `undefined`;
+
+exports[`functional:plugin > should not transform module if id matches exclude pattern 1`] = `undefined`;
+
+exports[`functional:plugin > should transform module if id matches include pattern 1`] = `
+"/**
+ * @file Fixtures - Button
+ * @module fixtures/Button
+ */
+
+import {
+  forwardRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type ForwardedRef
+} from 'react'
+import s, { css } from 'styled-components'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * Button background color.
+   *
+   * @default 'black'
+   */
+  $bg?: ButtonHTMLAttributes<HTMLButtonElement>['color']
+
+  /**
+   * Button text color.
+   *
+   * @default 'white'
+   */
+  $color?: ButtonHTMLAttributes<HTMLButtonElement>['color']
+
+  /**
+   * Button font size.
+   *
+   * @default '1.25rem'
+   */
+  $fontsize?: number | string
+
+  /**
+   * Mark button as disabled.
+   */
+  disabled?: boolean
+}
+
+interface CounterButtonProps extends ButtonProps {
+  /**
+   * Initial click count.
+   *
+   * @default 0
+   */
+  count?: number
+}
+
+/**
+ * Renders an HTML \`<button>\` element.
+ *
+ * @see https://developer.mozilla.org/docs/Web/HTML/Element/button
+ * @see https://developer.mozilla.org/docs/Web/API/HTMLButtonElement
+ *
+ * @visibleName Button
+ */
+const Button = s.button.attrs<ButtonProps>(p => ({
+  'aria-disabled': p.disabled ?? undefined,
+  'aria-hidden': p.hidden ?? undefined
+}))<ButtonProps>(p => {
+  return css\`
+    background-color: \${p.$bg};
+    color: \${p.$color};
+  \`
+})
+
+Button.defaultProps = {
+  $bg: 'black',
+  $color: 'white',
+  $fontsize: '1.25rem',
+  type: 'button'
+}
+
+/**
+ * Renders a button that displays how many times it has been clicked.
+ *
+ * @param {CounterButtonProps} [props={}] - Component props
+ * @param {ForwardedRef<HTMLButtonElement>} [ref] - \`<button>\` reference
+ * @return {JSX.Element} Counter button markup
+ */
+const CounterButton = forwardRef(function (
+  props: CounterButtonProps = {},
+  ref?: ForwardedRef<HTMLButtonElement>
+): JSX.Element {
+  const { count, ...rest } = props
+
+  const [clicks, setclicks] = useState<number>(count!)
+
+  /**
+   * Increases {@link clicks}.
+   *
+   * @return {void} Nothing when complete
+   */
+  const increment = (): void => setclicks(prev => prev + 1)
+
+  return (
+    <Button {...rest} onClick={increment} ref={ref}>
+      {clicks}
+    </Button>
+  )
+})
+
+CounterButton.displayName = 'CounterButton'
+CounterButton.defaultProps = {}
+
+export {
+  Button as default,
+  CounterButton,
+  type ButtonProps,
+  type CounterButtonProps
+}
+
+;Button.__docgenInfo={\\"tags\\":{\\"see\\":\\"https://developer.mozilla.org/docs/Web/HTML/Element/button\\\\nhttps://developer.mozilla.org/docs/Web/API/HTMLButtonElement\\",\\"visibleName\\":\\"Button\\"},\\"filePath\\":\\"\\",\\"description\\":\\"Renders an HTML \`<button>\` element.\\",\\"displayName\\":\\"Button\\",\\"methods\\":[],\\"props\\":{\\"ref\\":{\\"defaultValue\\":null,\\"description\\":\\"\\",\\"name\\":\\"ref\\",\\"parent\\":\\"_undefined_\\",\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"((instance: HTMLButtonElement | null) => void) | RefObject<HTMLButtonElement> | null\\"},\\"tags\\":{}},\\"$bg\\":{\\"defaultValue\\":{\\"value\\":\\"black\\"},\\"description\\":\\"Button background color.\\",\\"name\\":\\"$bg\\",\\"parent\\":{\\"fileName\\":\\"\\",\\"name\\":\\"ButtonProps\\"},\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"string\\"},\\"tags\\":{\\"default\\":\\"'black'\\"}},\\"$color\\":{\\"defaultValue\\":{\\"value\\":\\"white\\"},\\"description\\":\\"Button text color.\\",\\"name\\":\\"$color\\",\\"parent\\":{\\"fileName\\":\\"\\",\\"name\\":\\"ButtonProps\\"},\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"string\\"},\\"tags\\":{\\"default\\":\\"'white'\\"}},\\"$fontsize\\":{\\"defaultValue\\":{\\"value\\":\\"1.25rem\\"},\\"description\\":\\"Button font size.\\",\\"name\\":\\"$fontsize\\",\\"parent\\":{\\"fileName\\":\\"\\",\\"name\\":\\"ButtonProps\\"},\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"string | number\\"},\\"tags\\":{\\"default\\":\\"'1.25rem'\\"}},\\"theme\\":{\\"defaultValue\\":null,\\"description\\":\\"\\",\\"name\\":\\"theme\\",\\"parent\\":\\"_undefined_\\",\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"any\\"},\\"tags\\":\\"_duplicate_[\\\\\\"props\\\\\\",\\\\\\"ref\\\\\\",\\\\\\"tags\\\\\\"]\\"},\\"as\\":{\\"defaultValue\\":null,\\"description\\":\\"\\",\\"name\\":\\"as\\",\\"parent\\":\\"_undefined_\\",\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"undefined\\"},\\"tags\\":\\"_duplicate_[\\\\\\"props\\\\\\",\\\\\\"ref\\\\\\",\\\\\\"tags\\\\\\"]\\"},\\"forwardedAs\\":{\\"defaultValue\\":null,\\"description\\":\\"\\",\\"name\\":\\"forwardedAs\\",\\"parent\\":\\"_undefined_\\",\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"undefined\\"},\\"tags\\":\\"_duplicate_[\\\\\\"props\\\\\\",\\\\\\"ref\\\\\\",\\\\\\"tags\\\\\\"]\\"}}}
+;CounterButton.__docgenInfo={\\"tags\\":{\\"param\\":\\"props - Component props\\\\nref - \`<button>\` reference\\",\\"return\\":\\"Counter button markup\\"},\\"filePath\\":\\"\\",\\"description\\":\\"Renders a button that displays how many times it has been clicked.\\",\\"displayName\\":\\"CounterButton\\",\\"methods\\":[],\\"props\\":{\\"count\\":{\\"defaultValue\\":{\\"value\\":\\"0\\"},\\"description\\":\\"Initial click count.\\",\\"name\\":\\"count\\",\\"parent\\":{\\"fileName\\":\\"\\",\\"name\\":\\"CounterButtonProps\\"},\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"number\\"},\\"tags\\":{\\"default\\":\\"0\\"}},\\"$bg\\":{\\"defaultValue\\":{\\"value\\":\\"black\\"},\\"description\\":\\"Button background color.\\",\\"name\\":\\"$bg\\",\\"parent\\":{\\"fileName\\":\\"\\",\\"name\\":\\"ButtonProps\\"},\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"string\\"},\\"tags\\":{\\"default\\":\\"'black'\\"}},\\"$color\\":{\\"defaultValue\\":{\\"value\\":\\"white\\"},\\"description\\":\\"Button text color.\\",\\"name\\":\\"$color\\",\\"parent\\":{\\"fileName\\":\\"\\",\\"name\\":\\"ButtonProps\\"},\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"string\\"},\\"tags\\":{\\"default\\":\\"'white'\\"}},\\"$fontsize\\":{\\"defaultValue\\":{\\"value\\":\\"1.25rem\\"},\\"description\\":\\"Button font size.\\",\\"name\\":\\"$fontsize\\",\\"parent\\":{\\"fileName\\":\\"\\",\\"name\\":\\"ButtonProps\\"},\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"string | number\\"},\\"tags\\":{\\"default\\":\\"'1.25rem'\\"}},\\"disabled\\":{\\"defaultValue\\":null,\\"description\\":\\"Mark button as disabled.\\",\\"name\\":\\"disabled\\",\\"parent\\":{\\"fileName\\":\\"\\",\\"name\\":\\"ButtonProps\\"},\\"declarations\\":[],\\"required\\":false,\\"type\\":{\\"name\\":\\"boolean\\"},\\"tags\\":{}}}}"
+`;

--- a/src/__tests__/plugin.functional.spec.ts
+++ b/src/__tests__/plugin.functional.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * @file Functional Tests - plugin
+ * @module vite-plugin-react-docgen-typescript/tests/functional/plugin
+ *
+ * **Note**: Because snapshot tests will fail without setting `options.handler`,
+ * passing snapshot tests are also indicative of `options.handler`.
+ */
+
+import ctx from 'fixtures/transform-plugin-context'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import type { ComponentDoc, PropItem } from 'react-docgen-typescript'
+import type Options from '../options'
+import testSubject from '../plugin'
+
+describe('functional:plugin', () => {
+  const ACT: string = 'transform module'
+
+  /**
+   * Returns plugin options suitable for local **and** CI test environments.
+   *
+   * If file paths are included in snapshots, snapshot tests will **fail** in CI
+   * test environments. This is due to differences in file path resolutions.
+   *
+   * `opts` will be modified to prevent snapshot test failures related to file
+   * path resolutions.
+   *
+   * @param {Options} [opts={}] - Plugin options
+   * @return {Options} Plugin options for local and ci test environments
+   */
+  const options = (opts: Options = {}): Options => ({
+    ...opts,
+    /**
+     * Applies additional processing to `doc`.
+     *
+     * To prevent snapshot test failures related to file path resolutions, file
+     * paths in {@link ComponentDoc} and {@link PropItem} objects will be set to
+     * empty strings and the `declarations` field of `PropItem` objects will be
+     * set to an empty array.
+     *
+     * @param {ComponentDoc} doc - Component docgen info
+     * @return {ComponentDoc} Augmented component doc
+     */
+    handler(doc: ComponentDoc): ComponentDoc {
+      for (const key of Object.keys(doc.props)) {
+        const { parent }: PropItem = doc.props[key]!
+
+        doc.props[key] = Object.assign({}, doc.props[key]!, {
+          declarations: [],
+          parent: parent ? { ...parent, fileName: '' } : parent
+        })
+      }
+
+      doc.filePath = ''
+
+      return doc
+    },
+    /**
+     * In CI test environments, sourcemap generation will result in snapshot
+     * test failures due to differences in file path resolutions.
+     */
+    sourcemap: false
+  })
+
+  it(`should ${ACT} if id matches include pattern`, async () => {
+    // Arrange
+    const opts: Options = { include: ['**/**.tsx'] }
+    const id: string = path.resolve('__fixtures__/Button.tsx')
+    const code: string = await fs.readFile(id, 'utf8')
+    const subject = testSubject(options(opts))
+
+    // Act + Expect
+    expect(await subject.transform.call(ctx, code, id)).toMatchSnapshot()
+  })
+
+  it(`should not ${ACT} if id does not match include pattern`, async () => {
+    // Arrange
+    const id: string = faker.system.filePath()
+    const code: string = faker.datatype.string(faker.datatype.number())
+    const subject = testSubject()
+
+    // Act + Expect
+    expect(await subject.transform.call(ctx, code, id)).toMatchSnapshot()
+  })
+
+  it(`should not ${ACT} if id matches exclude pattern`, async () => {
+    // Arrange
+    const opts: Options = { exclude: ['**/**.stories.tsx'] }
+    const id: string = path.resolve('__fixtures__/Button.stories.tsx')
+    const code: string = await fs.readFile(id, 'utf8')
+    const subject = testSubject(opts)
+
+    // Act + Expect
+    expect(await subject.transform.call(ctx, code, id)).toMatchSnapshot()
+  })
+
+  it(`should not ${ACT} if docgen info is missing`, async () => {
+    // Arrange
+    const id: string = path.resolve('__fixtures__/empty.tsx')
+    const code: string = await fs.readFile(id, 'utf8')
+    const subject = testSubject()
+
+    // Act + Expect
+    expect(await subject.transform.call(ctx, code, id)).toMatchSnapshot()
+  })
+})

--- a/src/__tests__/plugin.spec.ts
+++ b/src/__tests__/plugin.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * @file Unit Tests - plugin
+ * @module vite-plugin-react-docgen-typescript/tests/unit/plugin
+ */
+
+import ctx from 'fixtures/transform-plugin-context'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import type { Testcase } from 'tests/interfaces'
+import { PLUGIN_NAME } from '../constants'
+import type Options from '../options'
+import testSubject from '../plugin'
+
+describe('unit:plugin', () => {
+  describe('@returns', () => {
+    it('should return PluginReactDocgenTypeScript', () => {
+      // Act
+      const subject = testSubject()
+
+      // Expect
+      expect(subject.enforce).to.be.a('string').that.equals('pre')
+      expect(subject.name).to.be.a('string').that.equals(PLUGIN_NAME)
+      expect(subject.transform).to.be.a('function')
+    })
+  })
+
+  describe('options', () => {
+    describe('options?.apply', () => {
+      type Case = Options['apply']
+
+      enum Apply {
+        BUILD = 'build',
+        SERVE = 'serve'
+      }
+
+      const cases: Case[] = [undefined, Apply.BUILD, Apply.SERVE, vi.fn()]
+
+      cases.forEach(apply => {
+        const option = 'PluginReactDocgenTypeScript.apply'
+        const args = pf([{ apply }])
+
+        it(`should set ${option} to ${pf(apply)} given ${args}`, () => {
+          expect(testSubject({ apply }).apply).to.equal(apply)
+        })
+      })
+    })
+
+    describe('options?.enforce', () => {
+      interface Case extends Testcase<NonNullable<Options['enforce']>> {
+        enforce?: Options['enforce']
+      }
+
+      enum Enforce {
+        POST = 'post',
+        PRE = 'pre'
+      }
+
+      const cases: Case[] = [
+        { enforce: undefined, expected: Enforce.PRE },
+        { enforce: Enforce.PRE, expected: Enforce.PRE },
+        { enforce: Enforce.POST, expected: Enforce.POST }
+      ]
+
+      cases.forEach(({ enforce, expected }) => {
+        const option = 'PluginReactDocgenTypeScript.enforce'
+        const args = pf([{ enforce }])
+
+        it(`should set ${option} to ${pf(expected)} given ${args}`, () => {
+          expect(testSubject({ enforce }).enforce).to.equal(expected)
+        })
+      })
+    })
+
+    describe('options?.shouldIncludeExpression', () => {
+      it('should not throw if ComponentDoc.expression is defined', async () => {
+        // Arrange
+        const options: Options = { shouldIncludeExpression: true }
+        const id: string = path.resolve('__fixtures__/List.tsx')
+        const subject = testSubject(options)
+
+        // Act + Expect
+        expect(await subject.transform.call(ctx, '', id)).to.not.throw
+      })
+    })
+
+    describe('options?.sourcemap', () => {
+      const id: string = path.resolve('__fixtures__/Counter.tsx')
+      const opts: Options = { sourcemap: undefined }
+      const opts_c: Options = { sourcemap: { includeContent: true } }
+      const opts_n: Options = { sourcemap: false }
+      const sd: string = 'Partial<SourceDescription>'
+
+      let code: string
+
+      beforeEach(async () => {
+        code = await fs.readFile(id, 'utf8')
+      })
+
+      it(`should return ${sd} given ${pf([opts])}`, async () => {
+        // Arrange
+        const subject = testSubject(opts)
+
+        // Act
+        const result = await subject.transform.call(ctx, code, id)
+
+        // Expect
+        expect(result).to.have.property('code')
+        expect(result).to.have.property('map')
+      })
+
+      it(`should return ${sd} given ${pf([opts_c])}`, async () => {
+        // Arrange
+        const subject = testSubject(opts_c)
+
+        // Act
+        const result = await subject.transform.call(ctx, code, id)
+
+        // Expect
+        expect(result).to.have.property('code')
+        expect(result)
+          .to.have.property('map')
+          .to.have.property('sourcesContent')
+          .that.deep.equals([code])
+      })
+
+      it(`should return string given ${pf([opts_n])}`, async () => {
+        // Arrange
+        const subject = testSubject(opts_n)
+
+        // Act
+        const result = await subject.transform.call(ctx, code, id)
+
+        // Expect
+        expect(result).to.be.a('string')
+        expect(result).to.not.have.property('code')
+        expect(result).to.not.have.property('map')
+      })
+    })
+  })
+})

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,5 +3,5 @@
  * @module vite-plugin-react-docgen-typescript/constants
  */
 
-/** @const {string} PLUGIN_NAME - Plugin name */
-export const PLUGIN_NAME: string = 'vite:react-docgen-typescript'
+/** @const {'vite:react-docgen-typescript'} PLUGIN_NAME - Plugin name */
+export const PLUGIN_NAME = 'vite:react-docgen-typescript' as const

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@
 export * from './constants'
 export type { default as Options } from './options'
 export * from './plugin'
+export type { default as PluginReactDocgenTypeScript } from './plugin-type'

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
 /**
  * @file RDT Plugin - Options
- * @module vite-plugin-react-docgen-typescript/Options
+ * @module vite-plugin-react-docgen-typescript/options
  */
 
 import type { SourceMapOptions } from 'magic-string'
@@ -34,13 +34,11 @@ interface Options extends ParserOptions {
   /**
    * Glob patterns matching files to exclude from parsing.
    *
-   * **Note**: Applied **after** {@link include}.
+   * @see https://github.com/micromatch/picomatch
    *
-   * @see https://github.com/micromatch/micromatch
-   *
-   * @default []
+   * @default ['**\/**.stories.tsx']
    */
-  exclude?: string[]
+  exclude?: (RegExp | string)[]
 
   /**
    * Apply additional processing to a `ComponentDoc` before `__docgenInfo` is
@@ -54,8 +52,6 @@ interface Options extends ParserOptions {
    * @param {string} code - Module code being transformed
    * @param {string} id - Path to module being transformed
    * @return {ComponentDoc | Promise<ComponentDoc>} Augmented `doc`
-   *
-   * @default doc=>doc
    */
   handler?(
     doc: ComponentDoc,
@@ -66,15 +62,14 @@ interface Options extends ParserOptions {
   /**
    * Glob patterns matching files to parse for docgen information.
    *
-   * @see https://github.com/micromatch/micromatch
+   * @see https://github.com/micromatch/picomatch
    *
-   * @default ['**.tsx']
+   * @default ['**\/**.tsx']
    */
-  include?: string[]
+  include?: (RegExp | string)[]
 
   /**
-   * Include [version 3 sourcemap][1] in final transform result for successfully
-   * parsed modules.
+   * Include [version 3 sourcemap][1] in transform result.
    *
    * [1]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit
    *

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@
  * @module vite-plugin-react-docgen-typescript/Options
  */
 
+import type { SourceMapOptions } from 'magic-string'
 import type { ComponentDoc, ParserOptions } from 'react-docgen-typescript'
 import type { Plugin } from 'vite'
 
@@ -86,6 +87,18 @@ interface Options extends ParserOptions {
    * @default doc=>doc.displayName
    */
   name?(doc: ComponentDoc, code: string, id: string): Promise<string> | string
+
+  /**
+   * Include [version 3 sourcemap][1] in final transform result for successfully
+   * parsed modules.
+   *
+   * [1]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit
+   *
+   * @see https://github.com/Rich-Harris/magic-string#sgeneratemap-options-
+   *
+   * @default true
+   */
+  sourcemap?: Omit<SourceMapOptions, 'source'> | boolean
 
   /**
    * Name of tsconfig file or path to tsconfig file.

--- a/src/options.ts
+++ b/src/options.ts
@@ -73,22 +73,6 @@ interface Options extends ParserOptions {
   include?: string[]
 
   /**
-   * Generate the name of the component to add a `__docgenInfo` property to.
-   *
-   * **Note**: `code` may have transforms from other plugins already applied.
-   *
-   * @see {@link ComponentDoc}
-   *
-   * @param {ComponentDoc} doc - Component docgen info object
-   * @param {string} code - Module code being transformed
-   * @param {string} id - Path to module being transformed
-   * @return {Promise<string> | string} Component name
-   *
-   * @default doc=>doc.displayName
-   */
-  name?(doc: ComponentDoc, code: string, id: string): Promise<string> | string
-
-  /**
    * Include [version 3 sourcemap][1] in final transform result for successfully
    * parsed modules.
    *

--- a/src/plugin-type.ts
+++ b/src/plugin-type.ts
@@ -28,9 +28,17 @@ interface PluginReactDocgenTypeScript extends Plugin {
   /**
    * Parses `id` for component docgen info.
    *
-   * For a successfully parsed module, the final transform result will include
-   * a new source map and updated version of `code` that includes logic to
-   * attach a `__docgenInfo` property to all components in `id`.
+   * For successfully parsed and transformed modules, the function will return
+   * an updated version of `code` that includes logic to add a `__docgenInfo`
+   * property to each component exported from `id`. If `options.sourcemap` is
+   * truthy, the function will also return a [version 3 sourcemap][1].
+   *
+   * If `id` doesn't meet filtering requirements (set by `options.exclude` and
+   * `options.include`), the function will return `undefined`. If `id` does end
+   * up being parsed, but doesn't yield any docgen information, `null` will be
+   * returned instead.
+   *
+   * [1]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit
    *
    * @async
    *

--- a/src/plugin-type.ts
+++ b/src/plugin-type.ts
@@ -1,0 +1,49 @@
+/**
+ * @file RDT Plugin - PluginReactDocgenTypeScript
+ * @module vite-plugin-react-docgen-typescript/type
+ */
+
+import type { TransformPluginContext, TransformResult } from 'rollup'
+import type { Plugin } from 'vite'
+import type { PLUGIN_NAME } from './constants'
+
+/**
+ * Vite `react-docgen-typescript` plugin type.
+ *
+ * @extends {Plugin}
+ */
+interface PluginReactDocgenTypeScript extends Plugin {
+  /**
+   * Plugin ordering.
+   *
+   * @see https://vitejs.dev/guide/api-plugin.html#plugin-ordering
+   */
+  enforce: Required<Plugin>['enforce']
+
+  /**
+   * Plugin name.
+   */
+  name: typeof PLUGIN_NAME
+
+  /**
+   * Parses `id` for component docgen info.
+   *
+   * For a successfully parsed module, the final transform result will include
+   * a new source map and updated version of `code` that includes logic to
+   * attach a `__docgenInfo` property to all components in `id`.
+   *
+   * @async
+   *
+   * @param {TransformPluginContext} this - Plugin context
+   * @param {string} code - Module code being transformed
+   * @param {string} id - Path to module being transformed
+   * @return {Promise<TransformResult>} Transform result
+   */
+  transform(
+    this: TransformPluginContext,
+    code: string,
+    id: string
+  ): Promise<TransformResult>
+}
+
+export type { PluginReactDocgenTypeScript as default }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,8 +3,15 @@
  * @module vite-plugin-react-docgen-typescript/plugin
  */
 
-import type { Plugin } from 'vite'
+import { createFilter } from '@rollup/pluginutils'
+import MagicString from 'magic-string'
+import path from 'node:path'
+import * as rdt from 'react-docgen-typescript'
+import type { TransformResult } from 'rollup'
+import * as telejson from 'telejson'
 import { PLUGIN_NAME } from './constants'
+import type Options from './options'
+import type PluginReactDocgenTypeScript from './plugin-type'
 
 /**
  * Creates a `react-docgen-typescript` plugin.
@@ -12,11 +19,113 @@ import { PLUGIN_NAME } from './constants'
  * @see https://github.com/styleguidist/react-docgen-typescript
  * @see https://vitejs.dev/guide/api-plugin.html
  *
- * @return {Plugin} Vite `react-docgen-typescript` plugin
+ * @param {Options} [options] - Plugin options
+ * @return {PluginReactDocgenTypeScript} Vite `react-docgen-typescript` plugin
  */
-const plugin = (): Plugin => {
+const plugin = ({
+  apply,
+  componentNameResolver,
+  enforce = 'pre',
+  customComponentTypes = [],
+  exclude = ['**/**.stories.tsx'],
+  handler,
+  include = ['**/**.tsx'],
+  propFilter = prop => !prop.parent?.fileName.includes('node_modules'),
+  savePropValueAsString = false,
+  shouldExtractLiteralValuesFromEnum = false,
+  shouldExtractValuesFromUnion = false,
+  shouldIncludeExpression = false,
+  shouldIncludePropTagMap = true,
+  shouldRemoveUndefinedFromOptional = true,
+  skipChildrenPropWithoutDoc = true,
+  sourcemap = true,
+  tsconfig = path.resolve('tsconfig.json')
+}: Options = {}): PluginReactDocgenTypeScript => {
+  /**
+   * Filter function that determines which modules should be operated on.
+   *
+   * @see https://github.com/rollup/plugins/tree/master/packages/pluginutils
+   *
+   * @const {(id: unknown) => boolean} filter
+   */
+  const filter: (id: unknown) => boolean = createFilter(include, exclude)
+
+  /**
+   * Component docgen info parser.
+   *
+   * @see https://github.com/styleguidist/react-docgen-typescript#usage
+   *
+   * @const {rdt.FileParser} parser
+   */
+  const parser: rdt.FileParser = rdt.withCustomConfig(tsconfig, {
+    componentNameResolver,
+    customComponentTypes,
+    propFilter,
+    savePropValueAsString,
+    shouldExtractLiteralValuesFromEnum,
+    shouldExtractValuesFromUnion,
+    shouldIncludeExpression,
+    shouldIncludePropTagMap,
+    shouldRemoveUndefinedFromOptional,
+    skipChildrenPropWithoutDoc
+  })
+
   return {
-    name: PLUGIN_NAME
+    apply,
+    enforce,
+    name: PLUGIN_NAME,
+    transform: async (code: string, id: string): Promise<TransformResult> => {
+      // do nothing if module should not be operated on
+      if (!filter(id)) return
+
+      /**
+       * Component docgen info parsed from {@link id}.
+       *
+       * @see {@link rdt.ComponentDoc}
+       *
+       * @const {rdt.ComponentDoc[]} docs
+       */
+      const docs: rdt.ComponentDoc[] = parser.parse(id)
+
+      // bail if missing component docgen info
+      if (docs.length === 0) return null
+
+      /**
+       * {@link code} as `MagicString`.
+       *
+       * @see https://github.com/Rich-Harris/magic-string
+       *
+       * @const {MagicString} src
+       */
+      const src: MagicString = new MagicString(code)
+
+      for (let doc of docs) {
+        // apply additional processing to component docgen info
+        if (handler) doc = await handler(doc, code, id)
+
+        /**
+         * {@link doc} stringified.
+         *
+         * @see https://github.com/storybookjs/telejson
+         *
+         * @const {string} __docgenInfo
+         */
+        const __docgenInfo: string = telejson.stringify(doc)
+
+        // add __docgenInfo property
+        src.append(`\n;${doc.displayName}.__docgenInfo=${__docgenInfo}`)
+      }
+
+      if (sourcemap === false) return src.toString()
+
+      return {
+        code: src.toString(),
+        map: src.generateMap({
+          ...(sourcemap === true ? { hires: true } : sourcemap),
+          source: id
+        })
+      }
+    }
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": false,
-    "lib": ["es2021"],
+    "jsx": "react-jsxdev",
+    "lib": ["dom", "es2021"],
     "module": "es2022",
     "moduleResolution": "node",
     "noEmit": true,
@@ -47,6 +48,7 @@
     "**/**/*.cjs",
     "**/**/*.mjs",
     "**/**/*.ts",
+    "**/**/*.tsx",
     "**/**/.*.cjs",
     "**/**/.*.ts"
   ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,14 @@ const config = (): UserConfig => {
       coverage: {
         all: true,
         clean: true,
-        exclude: ['**/__mocks__/**', '**/__tests__/**', 'src/index.ts'],
+        exclude: [
+          '**/__mocks__/**',
+          '**/__tests__/**',
+          'src/constants.ts',
+          'src/index.ts',
+          'src/options.ts',
+          'src/plugin-type.ts'
+        ],
         extension: ['.ts'],
         include: ['src'],
         reporter: ['json-summary', 'lcov', 'text'],
@@ -64,32 +71,37 @@ const config = (): UserConfig => {
        */
       maxThreads: 1,
       minThreads: 1,
-      mockReset: false,
+      mockReset: true,
       outputFile: {
         json: './__tests__/report.json'
       },
       passWithNoTests: true,
       reporters: [
-        'default',
         'json',
+        'verbose',
         ci ? new GithubActionsReporter() : './__tests__/reporters/notifier.ts'
       ],
       /**
-       * Stores snapshots next to test files.
+       * Stores snapshots next to `file`'s directory.
        *
        * @param {string} file - Path to test file
-       * @param {string} snapshot - Snapshot name
+       * @param {string} extension - Snapshot extension
        * @return {string} Custom snapshot path
        */
-      resolveSnapshotPath(file: string, snapshot: string): string {
-        return file + snapshot
+      resolveSnapshotPath(file: string, extension: string): string {
+        return path.resolve(
+          path.resolve(path.dirname(path.dirname(file)), '__snapshots__'),
+          path.basename(file).replace(/\.spec.tsx?/, '') + extension
+        )
       },
       restoreMocks: true,
       root: process.cwd(),
       setupFiles: ['./__tests__/setup/index.ts'],
       silent: false,
       snapshotFormat: {
-        printBasicPrototype: true
+        callToJSON: true,
+        min: false,
+        printFunctionName: true
       },
       testTimeout: 10 * 1000
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,7 +33,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.18.6":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.18.6, @babel/code-frame@npm:^7.5.5, @babel/code-frame@npm:^7.8.3":
   version: 7.18.6
   resolution: "@babel/code-frame@npm:7.18.6"
   dependencies:
@@ -42,14 +42,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.18.8":
+"@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.18.8":
   version: 7.18.8
   resolution: "@babel/compat-data@npm:7.18.8"
   checksum: 3436129f528c2953a07cbdc5bce1667d1579b35f8468d37042d03402401beab3ed21d4962a8fc9bcda2881a2b93eae0ffade85bcf1e383ffc4fa7bd92d20ad8f
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.12.3, @babel/core@npm:^7.17.7":
+"@babel/core@npm:7.12.9":
+  version: 7.12.9
+  resolution: "@babel/core@npm:7.12.9"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/generator": "npm:^7.12.5"
+    "@babel/helper-module-transforms": "npm:^7.12.1"
+    "@babel/helpers": "npm:^7.12.5"
+    "@babel/parser": "npm:^7.12.7"
+    "@babel/template": "npm:^7.12.7"
+    "@babel/traverse": "npm:^7.12.9"
+    "@babel/types": "npm:^7.12.7"
+    convert-source-map: "npm:^1.7.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.1"
+    json5: "npm:^2.1.2"
+    lodash: "npm:^4.17.19"
+    resolve: "npm:^1.3.2"
+    semver: "npm:^5.4.1"
+    source-map: "npm:^0.5.0"
+  checksum: a08673ed958cb1b39cd078a47000fb95ad6d0017113f3b96e463149295caf7e0ad5de39751fd17fcc750ee1007f397fb7abf8a8df76d2ea2dc70abf1d4dedd31
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.12.10, @babel/core@npm:^7.17.7, @babel/core@npm:^7.7.5":
   version: 7.18.9
   resolution: "@babel/core@npm:7.18.9"
   dependencies:
@@ -72,7 +96,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.18.9":
+"@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.12.5, @babel/generator@npm:^7.18.9":
   version: 7.18.9
   resolution: "@babel/generator@npm:7.18.9"
   dependencies:
@@ -83,7 +107,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.18.9":
+"@babel/helper-annotate-as-pure@npm:^7.16.0, @babel/helper-annotate-as-pure@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-annotate-as-pure@npm:7.18.6"
+  dependencies:
+    "@babel/types": "npm:^7.18.6"
+  checksum: 1fcc8f0e9377623a19e00de620391dba3e0343d82ae2142eb7c94b10d6dbddafc201a7a84d1d9ce45ec82291b887f9d85b83d53a50850cdf1b07cee79de554b9
+  languageName: node
+  linkType: hard
+
+"@babel/helper-builder-binary-assignment-operator-visitor@npm:^7.18.6":
+  version: 7.18.9
+  resolution: "@babel/helper-builder-binary-assignment-operator-visitor@npm:7.18.9"
+  dependencies:
+    "@babel/helper-explode-assignable-expression": "npm:^7.18.6"
+    "@babel/types": "npm:^7.18.9"
+  checksum: 657a94af70ae7fa17ebf228a9940804bb73bcef1851e36282590258b2630db5ff35439c5b4dc6c02fd9e825ded7e467d208e8beb0dbe5f7d751649dd39f6deb3
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.13.0, @babel/helper-compilation-targets@npm:^7.17.7, @babel/helper-compilation-targets@npm:^7.18.9":
   version: 7.18.9
   resolution: "@babel/helper-compilation-targets@npm:7.18.9"
   dependencies:
@@ -97,10 +140,82 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-environment-visitor@npm:^7.18.9":
+"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.18.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.18.6"
+    "@babel/helper-environment-visitor": "npm:^7.18.9"
+    "@babel/helper-function-name": "npm:^7.18.9"
+    "@babel/helper-member-expression-to-functions": "npm:^7.18.9"
+    "@babel/helper-optimise-call-expression": "npm:^7.18.6"
+    "@babel/helper-replace-supers": "npm:^7.18.9"
+    "@babel/helper-split-export-declaration": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 51d4e8fb66d4457199ab505c57e56c4244ea57e63b0980fc31082dc48cfa7e8ceab0574a38229d40de2f8e6d38b7a61ca990da72dd3b5d63883d8634e0da08e1
+  languageName: node
+  linkType: hard
+
+"@babel/helper-create-regexp-features-plugin@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.18.6"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.18.6"
+    regexpu-core: "npm:^5.1.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: e5068cbc803e5c5e3ef5dfd6d537754db712c5a3a92f165869b8b9b93f2207a79554666bfb96cbabaa126de58d08f4f157101b283c6ba46676f6d72691935e34
+  languageName: node
+  linkType: hard
+
+"@babel/helper-define-polyfill-provider@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "@babel/helper-define-polyfill-provider@npm:0.1.5"
+  dependencies:
+    "@babel/helper-compilation-targets": "npm:^7.13.0"
+    "@babel/helper-module-imports": "npm:^7.12.13"
+    "@babel/helper-plugin-utils": "npm:^7.13.0"
+    "@babel/traverse": "npm:^7.13.0"
+    debug: "npm:^4.1.1"
+    lodash.debounce: "npm:^4.0.8"
+    resolve: "npm:^1.14.2"
+    semver: "npm:^6.1.2"
+  peerDependencies:
+    "@babel/core": ^7.4.0-0
+  checksum: ea6c8944cad1be123e93878d56a656cb54c6a767edcecf2d3fe50117546e182f34009f8b9c9f89a6fb51c470f67571e8c7fc3ae9cdcbf31894b33a5cec2d16e8
+  languageName: node
+  linkType: hard
+
+"@babel/helper-define-polyfill-provider@npm:^0.3.1, @babel/helper-define-polyfill-provider@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@babel/helper-define-polyfill-provider@npm:0.3.2"
+  dependencies:
+    "@babel/helper-compilation-targets": "npm:^7.17.7"
+    "@babel/helper-plugin-utils": "npm:^7.16.7"
+    debug: "npm:^4.1.1"
+    lodash.debounce: "npm:^4.0.8"
+    resolve: "npm:^1.14.2"
+    semver: "npm:^6.1.2"
+  peerDependencies:
+    "@babel/core": ^7.4.0-0
+  checksum: ceebf63084b4e975bd121eff699c632820c9645c2fac36fb61f2ea456bbfe1c6e836dac8ebda54f3f8d9270a402ea400a1c53c20bc9e7f9d17aeef445576672b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-environment-visitor@npm:^7.18.6, @babel/helper-environment-visitor@npm:^7.18.9":
   version: 7.18.9
   resolution: "@babel/helper-environment-visitor@npm:7.18.9"
   checksum: 6a770ab046578d692f954213680f66d0764a92d608fcc121cf87c575223c44729fdebecc08550d0e18a5b22a3a72669c01de5351b6c1eff75a96b3167dbfe922
+  languageName: node
+  linkType: hard
+
+"@babel/helper-explode-assignable-expression@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-explode-assignable-expression@npm:7.18.6"
+  dependencies:
+    "@babel/types": "npm:^7.18.6"
+  checksum: 24d7f1d5a69a5bae6076db48f0ff83b51f947a5078574409954f93ff95ccc32b69ee71022c52d3385e22a707ed9efdd9185421f38c16fe6595b606ca4d604ffb
   languageName: node
   linkType: hard
 
@@ -123,7 +238,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.18.6":
+"@babel/helper-member-expression-to-functions@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.18.9"
+  dependencies:
+    "@babel/types": "npm:^7.18.9"
+  checksum: 17b2a855479ad09457a6f38a6084f6892ce707e4b1959c71a79be9700c68771b30e5cad46b265ced1c0ad92b0be67ac678ec2aa452dfa3eb29151473c08f8cc5
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.12.13, @babel/helper-module-imports@npm:^7.16.0, @babel/helper-module-imports@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-module-imports@npm:7.18.6"
   dependencies:
@@ -132,7 +256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.18.9":
+"@babel/helper-module-transforms@npm:^7.12.1, @babel/helper-module-transforms@npm:^7.18.6, @babel/helper-module-transforms@npm:^7.18.9":
   version: 7.18.9
   resolution: "@babel/helper-module-transforms@npm:7.18.9"
   dependencies:
@@ -148,12 +272,71 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-optimise-call-expression@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-optimise-call-expression@npm:7.18.6"
+  dependencies:
+    "@babel/types": "npm:^7.18.6"
+  checksum: d8d3756889d051393c30d859bd2b5c5ce039a8e1123ef15b0f96bbb6adc67a71e182a96d3308079faf7be80cfc4718283c981f83a9747e6e23e00088702db9bf
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:7.10.4":
+  version: 7.10.4
+  resolution: "@babel/helper-plugin-utils@npm:7.10.4"
+  checksum: b8cb2679e77d81950351e47c2092e6f928004660a84afbadd3cb2b387f337073ce04af723544e34496de4ed83f703f8cce95324bad6aab9564be67bfcb36ff19
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.13.0, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.16.7, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.18.9, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
+  version: 7.18.9
+  resolution: "@babel/helper-plugin-utils@npm:7.18.9"
+  checksum: ae01ad84af834f9cb787e19b4b38d3c518e4804327671a171ab0a1ec06b2f644c441db2d68ad7e91142acff643392bf674adc1877d9712ffef2dd57db4e8ca06
+  languageName: node
+  linkType: hard
+
+"@babel/helper-remap-async-to-generator@npm:^7.18.6":
+  version: 7.18.9
+  resolution: "@babel/helper-remap-async-to-generator@npm:7.18.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.18.6"
+    "@babel/helper-environment-visitor": "npm:^7.18.9"
+    "@babel/helper-wrap-function": "npm:^7.18.9"
+    "@babel/types": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: b1e869322e1c3a179b5bf3a33831489f801c729875d0ef9d134ab7a634d838550e05bb6a0ed3fc4130a0c2cb387824ce50b52be528f68c07b6d44fbbb2b018b0
+  languageName: node
+  linkType: hard
+
+"@babel/helper-replace-supers@npm:^7.18.6, @babel/helper-replace-supers@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-replace-supers@npm:7.18.9"
+  dependencies:
+    "@babel/helper-environment-visitor": "npm:^7.18.9"
+    "@babel/helper-member-expression-to-functions": "npm:^7.18.9"
+    "@babel/helper-optimise-call-expression": "npm:^7.18.6"
+    "@babel/traverse": "npm:^7.18.9"
+    "@babel/types": "npm:^7.18.9"
+  checksum: d77a39efeb9b879bf4d4267f2d6452f615f5ecf920f277fbf963dfb8824d464b3fd88d9f82c0a7a109eb19400597fab66e873f70b731ecac22a035a1d384e971
+  languageName: node
+  linkType: hard
+
 "@babel/helper-simple-access@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-simple-access@npm:7.18.6"
   dependencies:
     "@babel/types": "npm:^7.18.6"
   checksum: 59d09d4fab16a270448ffe46fb7006b3d5c4d1f790488382173736b4fb481cbed84f81ee73081dda6ef5eb890969a5be61710c6a6493ca35b8c54056d87d8988
+  languageName: node
+  linkType: hard
+
+"@babel/helper-skip-transparent-expression-wrappers@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.18.9"
+  dependencies:
+    "@babel/types": "npm:^7.18.9"
+  checksum: 68ea75a6534ccc1eb9458e027101cd99b3e87f9be0b2700eb8b4be94ef892f4b0a4ea9aac123cc3f8042593603c6e761934a45dd0f508de118abff48b354ba98
   languageName: node
   linkType: hard
 
@@ -180,7 +363,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.18.9":
+"@babel/helper-wrap-function@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-wrap-function@npm:7.18.9"
+  dependencies:
+    "@babel/helper-function-name": "npm:^7.18.9"
+    "@babel/template": "npm:^7.18.6"
+    "@babel/traverse": "npm:^7.18.9"
+    "@babel/types": "npm:^7.18.9"
+  checksum: 5e494fdf7ce12aea13e83d9959032283ba3fe72d991b875bb07432e3e69ba6a2bc3cc3106487ce1e4520053dfab7ce1f45f48889d509ce6c41be7d2e9eb7865a
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^7.12.5, @babel/helpers@npm:^7.18.9":
   version: 7.18.9
   resolution: "@babel/helpers@npm:7.18.9"
   dependencies:
@@ -202,12 +397,1116 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.18.6, @babel/parser@npm:^7.18.9":
+"@babel/parser@npm:^7.12.11, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.18.6, @babel/parser@npm:^7.18.9":
   version: 7.18.9
   resolution: "@babel/parser@npm:7.18.9"
   bin:
     parser: ./bin/babel-parser.js
   checksum: 88b4b247c092365e867ba96cd4d2d8344d9c4d899060071e0745c4c476b1ccb91f5cb487781577d5fcde0e15959dc2b0f1849ab06fd6b29ce4a5a52fda13f47c
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 15cb2c56bf44b12741de13e086d2e73878117357d2c7d94d302fda0f81da9ba63d0f6a43405cc0376c07d8fee15b38da6e6ed54fc9222101d55a63f3a0393db1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.18.9"
+    "@babel/plugin-proposal-optional-chaining": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.13.0
+  checksum: 5478bd798d3b8286f85b4c2e92b1c9f59f88ee7a8ccb5e2a380cbb746986e6531bf0bf02283f0cd21c81fb7ccf9082a8783612c05a97ef10d80b0a4b0d358606
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-async-generator-functions@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.18.6"
+  dependencies:
+    "@babel/helper-environment-visitor": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/helper-remap-async-to-generator": "npm:^7.18.6"
+    "@babel/plugin-syntax-async-generators": "npm:^7.8.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a9ebf015921b879ffa890caa559b0ef3c0e7698cc5e2a26aa20d69897d6009ece36d80bf8891c448f62025edda4ed7ad8e5ebf79b24ba68bb7e95aa8abef4124
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-class-properties@npm:^7.12.1, @babel/plugin-proposal-class-properties@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-class-properties@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 31561c055d0693c1f4e6738c26fa6e51f2db703c05d9b3f522d75d2052f3c35dd2eae0a36ed433e84b26e5f41a45ab2c09339873720600c89f5121771396e0fc
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-class-static-block@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-class-static-block@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/plugin-syntax-class-static-block": "npm:^7.14.5"
+  peerDependencies:
+    "@babel/core": ^7.12.0
+  checksum: 6ee8ac231dc32ced2f8ad83ee2f26cf75e41bd20debd98e3b8a39b562f3cdba47c6b3f6a24457876d23f3590d91cb76cfe3be159ec88e777012ca552ca743011
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-decorators@npm:^7.12.12":
+  version: 7.18.9
+  resolution: "@babel/plugin-proposal-decorators@npm:7.18.9"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": "npm:^7.18.9"
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/helper-replace-supers": "npm:^7.18.9"
+    "@babel/helper-split-export-declaration": "npm:^7.18.6"
+    "@babel/plugin-syntax-decorators": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 8244e932ec27abae6a97d75ff97c22d71792cbcccc4f3dbc5e421c4af08efa8a21b3acfe2ea93fc7b179688d69d76b73921b0a9d66338c2fb0ad0c6a215bb36f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-dynamic-import@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-dynamic-import@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 5ae2b563b314b74e740a658eb7735169af91b85867aeaffd4f688dfed8bfcaff404338d88c21d6c5fc3219b945b36088374bc888688367ae73774b461f4dce46
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-export-default-from@npm:^7.12.1":
+  version: 7.18.9
+  resolution: "@babel/plugin-proposal-export-default-from@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/plugin-syntax-export-default-from": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 22dd5df81536da195962c76f8437a79b40626cd33280fa1925a21e5ec79378bf9d2d6355443f92382862e00eb7c287484f6b00eb1016e98c551f7db748a52302
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-export-namespace-from@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-proposal-export-namespace-from@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/plugin-syntax-export-namespace-from": "npm:^7.8.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7fdc17902f379e554db2b7b17f2b9eb60cc1b1db2fd0c1bbdec0c405c302daa7447b5db0adeffb21e1db6e960fc616f9d1af71e31d52019c03b8d382d3e9ab62
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-json-strings@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-json-strings@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/plugin-syntax-json-strings": "npm:^7.8.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 07d1b37ca2f3f328180cf22f113af59225059df4712b8a6d41e600a2f3eeddf1d145042c811b4774892d0ef3a49f296974b82cf8d7d46f99c84f2c70dbe0ad28
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-logical-assignment-operators@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-proposal-logical-assignment-operators@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/plugin-syntax-logical-assignment-operators": "npm:^7.10.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 270048ba31db21089242eb2dfd91d0713825f4ba3d1b58dc69876bf8d9e92ff24181f9d7f4312bc26bb793707db8d2800145f9f34534bf34e016cef5447c8c34
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-nullish-coalescing-operator@npm:^7.12.1, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-nullish-coalescing-operator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.8.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: abe2f48358d1918d741352ee994371b8a934c7dd20e5962fdc564fe28f8986715a10acabc99ca883ee3195823d9f79096373848afb455bf61934fc4f81e11258
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-numeric-separator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-numeric-separator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/plugin-syntax-numeric-separator": "npm:^7.10.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6aea22e506394659f43ce083c31b53f0d79d3942afbabd499efe8b80aec35e60e2ea13559e14397fd753613bc0985a02d2dc0e68e2bd52b03ee325482b007707
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-object-rest-spread@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.12.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread": "npm:^7.8.0"
+    "@babel/plugin-transform-parameters": "npm:^7.12.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d21e5b6a5a98a051350a59b9e3e0af7675594c80e3e26816c76a5045cc2bc404e581f630adad74fb6265709d9b225551f54efd5e363304c1f6f6a6bdc9a8e0e9
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-object-rest-spread@npm:^7.12.1, @babel/plugin-proposal-object-rest-spread@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.18.9"
+  dependencies:
+    "@babel/compat-data": "npm:^7.18.8"
+    "@babel/helper-compilation-targets": "npm:^7.18.9"
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/plugin-syntax-object-rest-spread": "npm:^7.8.3"
+    "@babel/plugin-transform-parameters": "npm:^7.18.8"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4b576fe82f63838dc70704f7448b9511ef58e89716f547c7bd9e5f099fc9bb83d09ae51a63fb7a392e4c2f8bfd6a67023e9b6c97415034442243170a174e2e94
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-optional-catch-binding@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-optional-catch-binding@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/plugin-syntax-optional-catch-binding": "npm:^7.8.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 792601eacca8714c25f8e6bb06734e3fed1a52ef5cd3acd070a8480c0e0344c5f3546c165502e59163f09fa7405393a90981106e01c06dff1d7639ca77f2263a
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-optional-chaining@npm:^7.12.7, @babel/plugin-proposal-optional-chaining@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.18.9"
+    "@babel/plugin-syntax-optional-chaining": "npm:^7.8.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a86e79b2759d8bfdee5d84f0199ca026eb0016bbbdbe85b835a1426f2a32c3f81a0ec919585fc345d08dbdeec6643aab25008ba1b244c13c8da0cf051a6f06a1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-private-methods@npm:^7.12.1, @babel/plugin-proposal-private-methods@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-private-methods@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ead2a2435e83b8571a21a26df15502a470a1f73c21a790c1f8830508a21c68621b23866e04495901fa2fc482bfa7909cbab7c55266dfddf3b50c0f65ffbc0201
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-private-property-in-object@npm:^7.12.1, @babel/plugin-proposal-private-property-in-object@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.18.6"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.18.6"
+    "@babel/helper-create-class-features-plugin": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/plugin-syntax-private-property-in-object": "npm:^7.14.5"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: aadc79cc06dfd5298d6dcca269a8f2cb007692ce1c18454933a0fe40780e94ddb3c3b8439ead1a3eec88fe0c67b102b77f703f5f7a988f2cd88bc255df8af34c
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-unicode-property-regex@npm:^7.18.6, @babel/plugin-proposal-unicode-property-regex@npm:^7.4.4":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-unicode-property-regex@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: cb478bcdb48c37c67a8e65903c6fdfea07a3e66447f49f07691a4edfa6a0a3a984f6c685a057884ca13568d6799aaee295b335bece9f046dc9929cc0f201193d
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-async-generators@npm:^7.8.4":
+  version: 7.8.4
+  resolution: "@babel/plugin-syntax-async-generators@npm:7.8.4"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 518ee81097d43f6a439cfe91c708cca9bf67a32f0ec6f65df3c34d8b1ce51b473f77040345684792c60ac89e1c78c0a6eacbc31592bc1d912f06e9e0c3f80716
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-class-properties@npm:^7.12.13":
+  version: 7.12.13
+  resolution: "@babel/plugin-syntax-class-properties@npm:7.12.13"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.12.13"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7a9d076a55d11a53bee2b2c5b05a827f0bc5e13b805d7cd801e3e39b4068b88ca6ed5c7ae7ed2df5259e02515cc0f095468bd8ad4f0609f32adf3abfa3d077cf
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-class-static-block@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-class-static-block@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.14.5"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a9f8be55e4182dedb4204d16c60cfeeda7ab8a1e01943799fca7ef9bbfad1a84a65b4f768649300203d8035cc1ff0c373d0c56a635305e44df90778b1c4424c3
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-decorators@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-decorators@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6ece1e678211ef9cd3a833b9f8de5896d90287fd09e6345b0b7f405ab2b10b4ade6381b3f45c8fa465908e475464abad86fd9ca9a3d02506237e815fbd8f2a96
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-dynamic-import@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-dynamic-import@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 5552799d34dc934c8b7ccd796bd47f3d6e6413e5f863effdc1f3575bc14865e1737d6c48bf2ac80489c27d0e1240a7a19e38876853b67ab976f6c3554e2675b4
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-export-default-from@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-export-default-from@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: fb5fb49c5c9d196cc16cdbce0582a2a4927b3872b853d17f1b15decb1769492a45fb6dfaa4a6dc4019f62b10ee79fdeedce48a8678783aba40e39c91105a84e5
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-export-namespace-from@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-export-namespace-from@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 100efed7687c752a9cc37d32fa64e537838f2cbc128393b078b1d1894b4bd3a9055365a6249f0716710ee427377a0b00e9d7e9573f59842b797b727e3c90b402
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-flow@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-flow@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 411eb17525a3149c6d17755234ccd703a7ec7a592733d3305e6c802971b029933d8b5553af06b5023a6ce156d783bb4e93e73e666842ad1bb81310fcaa57e9cd
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-import-assertions@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-import-assertions@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0401bca7a83dfda76cc8f69f680be52b72f8f1a875ed70752eccf0b571f19e6300a31277a130034c61de11d19d82f48cdd2daf75efd127d2c218a0bc93c2baff
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-json-strings@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-json-strings@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d21aa96f15268f923f70e49155059ca220a7f7da3cec5072121fb8342527fc9e5753455cd61318054a170b1ecba13fd1891eb2c67f28a1c335af5bbaf52b93d0
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@babel/plugin-syntax-jsx@npm:7.12.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.10.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3204de23f821a3cd1bdd16becf05378c4e05990bfc90d3361f1cce220b4660a661341e3638e6a9635504f5cae062eabcd3242c7f9d11bb6d4ea68153b899236e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 93aa8b4803ade912560529ffebed69cf29617f5025fdd39eeea3b2c60fa16f7120dee3e310931fd8faf14e2bd0bc5227210efea987bd393e61dcb4287d9aac8b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-logical-assignment-operators@npm:^7.10.4":
+  version: 7.10.4
+  resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.10.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3a01f61a5b0f429dadbfb58d979c550c496ead9121282319406398cc76f7a6dfb58c20c9782b6b1b1b74f938add3edd962a3f699bf407deda003f84708b94c7e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-nullish-coalescing-operator@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-nullish-coalescing-operator@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: cc19c595a643531cdfa41eb9d5941ae1734049d9fdad127ed262225a657d3c2dce95aeb3e40019e6f1b0403e1656fc6170b43c2fbafceab0d6fa2502a62c91d8
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-numeric-separator@npm:^7.10.4":
+  version: 7.10.4
+  resolution: "@babel/plugin-syntax-numeric-separator@npm:7.10.4"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.10.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 32689c162862617fad6bfd12efed7523bf9985d396cb3eec12ef1fc96ba225600d3ea30c22051bb21dd8c8fd156fdef366e44150c3c19ef7eb7a85903a9445b4
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-object-rest-spread@npm:7.8.3, @babel/plugin-syntax-object-rest-spread@npm:^7.8.0, @babel/plugin-syntax-object-rest-spread@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-object-rest-spread@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 868f8cd0c2e10511056a089dab2e88f329b432b81766702de1d8970a785fdae32bd022a69359a7ca6fc58d4767418b871e88fe99ab4209afbaea5e62ebd82ada
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-optional-catch-binding@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-optional-catch-binding@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c6277360d55c4b4dbaca9fbaf279fe2783e1c0cc1f8edb41feb6f14d5b7ce1f25ca1ab4cf3d0e78411a16d3ee36d4ffd3ee30d07dbf47b67880cd707492c3158
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-optional-chaining@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-optional-chaining@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: fd81239a2b6c02b3f8cc2abc94db405afb8292133602a9d649985f40ca92153fdfca812dae6ac273a5bd7752c1a46cd4835e5a8bcf3541388d4ece480657fe7f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-private-property-in-object@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-private-property-in-object@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.14.5"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 944728155d4fc2f5dda9e81cac64a773f2b800cb19d2c9361d111a6fccb354dae8517a83bfc5abf5d557b10db2e759d1b48cc002f2330c46cff09339b76a987b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-top-level-await@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-top-level-await@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.14.5"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d62a60c7ade2ee033c6037d1fbabb9802c8e03a79e19d33e2fb597f85b2a1a90f6718cdb532252d69ae005e3ac3b1fd29860c1858f8463c3700a81d681967473
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-typescript@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-typescript@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 99aaa2a38b3cfc19427c04b0eebfdda3dc2c02a538dfc70c9c6e651db82a5abe71c94d6f59f2113204a61ef053e5f05b76ef94ddcc1dd6c624237dc35ddb43d1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-arrow-functions@npm:^7.12.1, @babel/plugin-transform-arrow-functions@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-arrow-functions@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d4835ab8e4808b67e49daeb473f8e5a1da4bae7253f0f13a5532391b9bfceb447b86274e31df52037457daf8c04950f77348669935899fdc794ad2b72eb30604
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-async-to-generator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-async-to-generator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/helper-remap-async-to-generator": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 06c129db0fb250e3711df474a1a7c32c7587bd09291a247e0176e2b9d4143162144b1f88f40f8c09aa14d4c03c6e93d2c42c627d96fec9924e91774e33a03260
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-block-scoped-functions@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 34ec13635c2140b089fb63e79fd3888c0a19ec6c37a24c5157febadf85dfc66c0b1527b07006dca9bfa2bc3e5009eac2b7207f55b505ca3ee65ebdcf7fda98eb
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-block-scoping@npm:^7.12.12, @babel/plugin-transform-block-scoping@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: bf66bb299d677244ad2e505016f5e7d7c347a460a09e2e62d7d8ba6d08c2f57c899add36ac294cc0ee36450bb30ca4ca68030890aa5a5b6bda38a26d03562d30
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-classes@npm:^7.12.1, @babel/plugin-transform-classes@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-classes@npm:7.18.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.18.6"
+    "@babel/helper-environment-visitor": "npm:^7.18.9"
+    "@babel/helper-function-name": "npm:^7.18.9"
+    "@babel/helper-optimise-call-expression": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/helper-replace-supers": "npm:^7.18.9"
+    "@babel/helper-split-export-declaration": "npm:^7.18.6"
+    globals: "npm:^11.1.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: f6fb44df379840ab6cdff1532d21e2921ccfa60d941f2255e7e1caa7b55680db17a409b5c51a132802d1311554f6fc3effa5b685c7b15edab1b43bd592a5a3de
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-computed-properties@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-computed-properties@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 84ddb59a7c9aef0dbee1f022e3d1a4faa0b4b856f4a483f0b1c267651469008294e64b1a9e433ac1a4600a5d6ef6467ed09e22e66f1cc812ee33014619882fe1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-destructuring@npm:^7.12.1, @babel/plugin-transform-destructuring@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-destructuring@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c72b3f94384548e88bd7f8ede6a45667b5c0c7a52cbd4292360ee9cf4142db85f72a3d6a625427a933371f3f96984c1a64731c3ddb0443f62126da718b16e363
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-dotall-regex@npm:^7.18.6, @babel/plugin-transform-dotall-regex@npm:^7.4.4":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-dotall-regex@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 1d2add05dbbaef2b116289ae7d0f8aa6d3e7e7c57cfccebb0e42d7b659b881f7842d058f8849e3a44f1440c34ecc8f56b7ebdc66a2d2641dc5020bf292aa0a4a
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-duplicate-keys@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-duplicate-keys@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c4a9d84500f525e0137985d709f84f175ec5f9252977f6775fa34117a6b34afae411e74a5ed455e39bcf29a38254f7b4051440ff0d538ef60850f28b4a6e2c6c
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-exponentiation-operator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: f74b8b8e99bdaff935ffe23d4d72ce9d81050e71ba36caa7a0773354877fe51f00626981f822aa0d9ef7abc0a6c3731ccaa14f83e1642ac154c7b418dd2f06e7
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-flow-strip-types@npm:^7.18.6":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-flow-strip-types@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/plugin-syntax-flow": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6eca02fdc328f0073e77b751a74e0c71a723aad038bfaf1b6a358791d0a1c4bc00d19bcb39de245c39600dcff3997c08c79e9a0b86f11157dfa56dbfc450ae7d
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-for-of@npm:^7.12.1, @babel/plugin-transform-for-of@npm:^7.18.8":
+  version: 7.18.8
+  resolution: "@babel/plugin-transform-for-of@npm:7.18.8"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: cf76cdab736f2b615f3c084375c600e9df02a6c0b2801f15599ffab6bcfd045b0bb483eb8a5e3b9776485b652745e99aeb01b1277dc7a9bc52df08c5665d1f97
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-function-name@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-function-name@npm:7.18.9"
+  dependencies:
+    "@babel/helper-compilation-targets": "npm:^7.18.9"
+    "@babel/helper-function-name": "npm:^7.18.9"
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ab6b97c4d3b02d850527d491d4bf224dfbc0cbfdccbf1222dedaf6817f7aac6269974bed9271790bdc1c5e623c9885a3db0d0ea24b44af006b7447e8c69672c8
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-literals@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-literals@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4856c2c3b34c8d828a2ba2301cc6ea5ba06869d82e39b4e81497c02b84dacf487f34c95a1ffff5e36a39a297ec869ed1052b0c975bea387a0192c654126cd6cf
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-member-expression-literals@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-member-expression-literals@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6f62212c69138d80568e3cff6b2ffafa812da1779095ba7373c253c33db18dc31808b6ee4ad8b188b8cfa6be819a87c316ab1b73cf0f0ff1b9d9e730fc0645f6
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-amd@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-modules-amd@npm:7.18.6"
+  dependencies:
+    "@babel/helper-module-transforms": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    babel-plugin-dynamic-import-node: "npm:^2.3.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 62a192e30db5ba68e38eba5471cbf5793a629c966be188313497d49dfca014a7cf0b740d02c16395663fde499a153c642f957cf7776b57567c58d1a3876d5d67
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-commonjs@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.18.6"
+  dependencies:
+    "@babel/helper-module-transforms": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/helper-simple-access": "npm:^7.18.6"
+    babel-plugin-dynamic-import-node: "npm:^2.3.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 9f0e61ccdb996d335bda1cedb3369de242b470ed884065d20ed593f855354722c46ee8f34c7fedebf0afefbbebbae22d29b8eed5a94e0eb0ef982f16e6f0fce9
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-systemjs@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.18.9"
+  dependencies:
+    "@babel/helper-hoist-variables": "npm:^7.18.6"
+    "@babel/helper-module-transforms": "npm:^7.18.9"
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/helper-validator-identifier": "npm:^7.18.6"
+    babel-plugin-dynamic-import-node: "npm:^2.3.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 59be88ca9fe9cb90917f39b8799f0644d49d4c7ede63e5b4d7e3c32327fa6a349bdc70d8034b965080d299f72b0e2df91a03d5e1bc4dca95bb88e233cc63fffa
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-umd@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-modules-umd@npm:7.18.6"
+  dependencies:
+    "@babel/helper-module-transforms": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: e28c87c53cf8255e44cd04d1f7dcb38f76cf5ab96d96e0444efa6e4c6ed3fb5fb70956dc2f75927dce0357303e2c47bbd193efe1dbf38ab1a057ad72dfae110e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 69dca35797939d77ec48819ac2f82727cf7aabe8d234a5d0961efd4637e5a0f535ea8d30690e83be5263116d98efbd11ec0f9ed03d8363327236398446ccd537
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-new-target@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-new-target@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: df67eeb4a8b4bdbba1db57171ceb91d25a5acd668f8407364ab6c669f2a428d0cd9f574603866129b707c20010e95681147d2d5a4ea1676ebd1e115af6fb134c
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-object-super@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-object-super@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/helper-replace-supers": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0d0e4a2750a89fa93505c974d871e8ddcad510c7d5417625154615d787920f34520299f50d47b74157e6460763614f1c4ea35737b25d83bff97a4abe0d87b70b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-parameters@npm:^7.12.1, @babel/plugin-transform-parameters@npm:^7.18.8":
+  version: 7.18.8
+  resolution: "@babel/plugin-transform-parameters@npm:7.18.8"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7d8c19cbae0ddaf1b7c5205315b3a0ed19884f4732dbf384b35b4710981a678f82bd03a08b089a5fa4f3cd5449701b89d36bd8a95fd341c8fe2d3ac3aea01039
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-property-literals@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-property-literals@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: bf10d57225db63184b996f48b565e9b3a611ef0e711c889835a4246ac44b11918aa181aa2b59fee384ad7eb33b687e2c593af392803a6d7f13b0f1220467f71e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-display-name@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-react-display-name@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 945b758eefe02d4354b8e5d57107300e406dbe177fea00c19cc0a07b488b697026315a76e4552a5d6ee95a4402e24bd08ff0346ca77401af02d24c5299182e20
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx-development@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-react-jsx-development@npm:7.18.6"
+  dependencies:
+    "@babel/plugin-transform-react-jsx": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 477254957b62413d6006b99022308ccd80713f9f7f3f5ff22ff28a3c6d752e69827c6b40c58374cba3e3087c25f6e342325b882e2ab9144e906203fa67cc58d1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx@npm:^7.12.12, @babel/plugin-transform-react-jsx@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-react-jsx@npm:7.18.6"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.18.6"
+    "@babel/helper-module-imports": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/plugin-syntax-jsx": "npm:^7.18.6"
+    "@babel/types": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 255834d4b7389b5cf67505ad3ace7932c9439f1573408418ac65a32a9ff6948d0c3689ede4e84b977676e1853ff64ff885dc2df030e2379e3a9e57ae7294b106
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-pure-annotations@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-react-pure-annotations@npm:7.18.6"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3699e57951d672d67b3ce8374ff85d18731108cfd64be9ef55b8ab14bf6d80765a5f5ac85457d0b3ab2747619e6032796e125440c11acc2af86e937c4fe083df
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-regenerator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-regenerator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    regenerator-transform: "npm:^0.15.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 57e1da7a05c619a9231ded3c33a73aec2d2b90f6266f4bd30f6aeeec86efc7757e32e4100f10cfd4992657b95242a45691ed8f7baf5f238eadeb8992ea24687e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-reserved-words@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-reserved-words@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 431eada54dabf8d1fc915552665c0f40d37a5d7ce40f67647ccb48535dd29699facb1fe93c26346f00429508fa8a7f7baa277e36a9d7a070c0b0fc54e96e417b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-shorthand-properties@npm:^7.12.1, @babel/plugin-transform-shorthand-properties@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-shorthand-properties@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2950da9e062bbb3a7fc84d8b9735d06dd93fe896640f197dc75cf85494686b58fa62c435bcbf9295873a206c5b029c650bcbf3ca60fa156e819d5293951cbb35
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-spread@npm:^7.12.1, @babel/plugin-transform-spread@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-spread@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 9a8a28ebad5db2c7c79c7f54945eb6cb681bc7522c59c422798175d86d6df837d35820d2c48d676db02c102d403811b4c4a891be270a4fd74495dd849acc03b1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-sticky-regex@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-sticky-regex@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d9b562dc0625b6210a15d434da49bd01ee10a46476bc7824ea15f9c9207d6e0bee09a7eca5146a5eac82a7d658f0188f65009f87db49871e1627fb8c3d53da7e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-template-literals@npm:^7.12.1, @babel/plugin-transform-template-literals@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-template-literals@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: fc06206e58e6fc2d5678349c8d15b96099efdbcf59b6f394ced250c56d87fc6f03d8c4360a96d5d8738c59dc4b6b472395f95489396033769d28be9a2fe9ac91
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-typeof-symbol@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-typeof-symbol@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 257da06cf9b382ceb1e31ce17c91627cdfd324a03b21f5e20354516d99aaa0fb8be1f8bd0ecc97f83243e3931346b1faf7a6d14cfb5aba97f9e3dcb4bfad6af1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-typescript@npm:^7.18.6":
+  version: 7.18.8
+  resolution: "@babel/plugin-transform-typescript@npm:7.18.8"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/plugin-syntax-typescript": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: addf72e1c303426f9376052d78380da7a58ac03bea636cb94d2aff436d96879e07f7c33c6426a50c48a7961a25c76feeb221b001597aae7929b60043ce2bbf43
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-unicode-escapes@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-unicode-escapes@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 9866ed822841bdb1da684126503662e98590a1cc978673658e9bb173649868e6dabfc303dbd80f96e0b2860c38bdee6dd26575f65c90e8ec9a0e143ca76b3e96
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-unicode-regex@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-unicode-regex@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.18.6"
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b9b7c9b7e57d0db863697a76391a7aa891e9e694b25bd94d1b2fe4beb2d183786469b8fb38084521b76f556b169ac5de14d4bbd281ad4e739ed8d0b219ae7782
+  languageName: node
+  linkType: hard
+
+"@babel/preset-env@npm:^7.12.11":
+  version: 7.18.9
+  resolution: "@babel/preset-env@npm:7.18.9"
+  dependencies:
+    "@babel/compat-data": "npm:^7.18.8"
+    "@babel/helper-compilation-targets": "npm:^7.18.9"
+    "@babel/helper-plugin-utils": "npm:^7.18.9"
+    "@babel/helper-validator-option": "npm:^7.18.6"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "npm:^7.18.6"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "npm:^7.18.9"
+    "@babel/plugin-proposal-async-generator-functions": "npm:^7.18.6"
+    "@babel/plugin-proposal-class-properties": "npm:^7.18.6"
+    "@babel/plugin-proposal-class-static-block": "npm:^7.18.6"
+    "@babel/plugin-proposal-dynamic-import": "npm:^7.18.6"
+    "@babel/plugin-proposal-export-namespace-from": "npm:^7.18.9"
+    "@babel/plugin-proposal-json-strings": "npm:^7.18.6"
+    "@babel/plugin-proposal-logical-assignment-operators": "npm:^7.18.9"
+    "@babel/plugin-proposal-nullish-coalescing-operator": "npm:^7.18.6"
+    "@babel/plugin-proposal-numeric-separator": "npm:^7.18.6"
+    "@babel/plugin-proposal-object-rest-spread": "npm:^7.18.9"
+    "@babel/plugin-proposal-optional-catch-binding": "npm:^7.18.6"
+    "@babel/plugin-proposal-optional-chaining": "npm:^7.18.9"
+    "@babel/plugin-proposal-private-methods": "npm:^7.18.6"
+    "@babel/plugin-proposal-private-property-in-object": "npm:^7.18.6"
+    "@babel/plugin-proposal-unicode-property-regex": "npm:^7.18.6"
+    "@babel/plugin-syntax-async-generators": "npm:^7.8.4"
+    "@babel/plugin-syntax-class-properties": "npm:^7.12.13"
+    "@babel/plugin-syntax-class-static-block": "npm:^7.14.5"
+    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
+    "@babel/plugin-syntax-export-namespace-from": "npm:^7.8.3"
+    "@babel/plugin-syntax-import-assertions": "npm:^7.18.6"
+    "@babel/plugin-syntax-json-strings": "npm:^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators": "npm:^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.8.3"
+    "@babel/plugin-syntax-numeric-separator": "npm:^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread": "npm:^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding": "npm:^7.8.3"
+    "@babel/plugin-syntax-optional-chaining": "npm:^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object": "npm:^7.14.5"
+    "@babel/plugin-syntax-top-level-await": "npm:^7.14.5"
+    "@babel/plugin-transform-arrow-functions": "npm:^7.18.6"
+    "@babel/plugin-transform-async-to-generator": "npm:^7.18.6"
+    "@babel/plugin-transform-block-scoped-functions": "npm:^7.18.6"
+    "@babel/plugin-transform-block-scoping": "npm:^7.18.9"
+    "@babel/plugin-transform-classes": "npm:^7.18.9"
+    "@babel/plugin-transform-computed-properties": "npm:^7.18.9"
+    "@babel/plugin-transform-destructuring": "npm:^7.18.9"
+    "@babel/plugin-transform-dotall-regex": "npm:^7.18.6"
+    "@babel/plugin-transform-duplicate-keys": "npm:^7.18.9"
+    "@babel/plugin-transform-exponentiation-operator": "npm:^7.18.6"
+    "@babel/plugin-transform-for-of": "npm:^7.18.8"
+    "@babel/plugin-transform-function-name": "npm:^7.18.9"
+    "@babel/plugin-transform-literals": "npm:^7.18.9"
+    "@babel/plugin-transform-member-expression-literals": "npm:^7.18.6"
+    "@babel/plugin-transform-modules-amd": "npm:^7.18.6"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.18.6"
+    "@babel/plugin-transform-modules-systemjs": "npm:^7.18.9"
+    "@babel/plugin-transform-modules-umd": "npm:^7.18.6"
+    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.18.6"
+    "@babel/plugin-transform-new-target": "npm:^7.18.6"
+    "@babel/plugin-transform-object-super": "npm:^7.18.6"
+    "@babel/plugin-transform-parameters": "npm:^7.18.8"
+    "@babel/plugin-transform-property-literals": "npm:^7.18.6"
+    "@babel/plugin-transform-regenerator": "npm:^7.18.6"
+    "@babel/plugin-transform-reserved-words": "npm:^7.18.6"
+    "@babel/plugin-transform-shorthand-properties": "npm:^7.18.6"
+    "@babel/plugin-transform-spread": "npm:^7.18.9"
+    "@babel/plugin-transform-sticky-regex": "npm:^7.18.6"
+    "@babel/plugin-transform-template-literals": "npm:^7.18.9"
+    "@babel/plugin-transform-typeof-symbol": "npm:^7.18.9"
+    "@babel/plugin-transform-unicode-escapes": "npm:^7.18.6"
+    "@babel/plugin-transform-unicode-regex": "npm:^7.18.6"
+    "@babel/preset-modules": "npm:^0.1.5"
+    "@babel/types": "npm:^7.18.9"
+    babel-plugin-polyfill-corejs2: "npm:^0.3.1"
+    babel-plugin-polyfill-corejs3: "npm:^0.5.2"
+    babel-plugin-polyfill-regenerator: "npm:^0.3.1"
+    core-js-compat: "npm:^3.22.1"
+    semver: "npm:^6.3.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ff780ba74dccffd867bf06495a7883f73d4b31056da6f17356b14d40e1793bb182d6f05e9bf13ee05cf19d19dc537ddedc0ec1deb41dd0373d1503b6fd78c9c9
+  languageName: node
+  linkType: hard
+
+"@babel/preset-flow@npm:^7.12.1":
+  version: 7.18.6
+  resolution: "@babel/preset-flow@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/helper-validator-option": "npm:^7.18.6"
+    "@babel/plugin-transform-flow-strip-types": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3f8aff3111db864465cc824c780581e0e1ea94094d8759dc5d1098248c64e8cc7613560699c891ad888ddc852ec9e0fd1f679faed748659eefbd29abb6318dee
+  languageName: node
+  linkType: hard
+
+"@babel/preset-modules@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "@babel/preset-modules@npm:0.1.5"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.0.0"
+    "@babel/plugin-proposal-unicode-property-regex": "npm:^7.4.4"
+    "@babel/plugin-transform-dotall-regex": "npm:^7.4.4"
+    "@babel/types": "npm:^7.4.4"
+    esutils: "npm:^2.0.2"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ebba2ca33850f53f9f45ed2c9d4bb1add9438e2b0321064d232dc3abc64b5e102194557aa5719bfc8384fc5f76595b8723e4cb8e41cb79599d4efcf6fb650cc3
+  languageName: node
+  linkType: hard
+
+"@babel/preset-react@npm:^7.12.10":
+  version: 7.18.6
+  resolution: "@babel/preset-react@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/helper-validator-option": "npm:^7.18.6"
+    "@babel/plugin-transform-react-display-name": "npm:^7.18.6"
+    "@babel/plugin-transform-react-jsx": "npm:^7.18.6"
+    "@babel/plugin-transform-react-jsx-development": "npm:^7.18.6"
+    "@babel/plugin-transform-react-pure-annotations": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: bcbfa54165b705a930ad179394782a16840027aaa609437c98227c38ea72bc12f46d7e062c3965d4b6dd748c7f6b17b2fd609b75191b7441211dba32f0cc11ce
+  languageName: node
+  linkType: hard
+
+"@babel/preset-typescript@npm:^7.12.7":
+  version: 7.18.6
+  resolution: "@babel/preset-typescript@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+    "@babel/helper-validator-option": "npm:^7.18.6"
+    "@babel/plugin-transform-typescript": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 216a8afe21226496bbac1f8d6ef9462f6bdb98db8495aa382f67fec895c1d3526d204536a4856677fa1a73513bb4ff0623846cbda9a5dc20cd38260063a20bdf
+  languageName: node
+  linkType: hard
+
+"@babel/register@npm:^7.12.1":
+  version: 7.18.9
+  resolution: "@babel/register@npm:7.18.9"
+  dependencies:
+    clone-deep: "npm:^4.0.1"
+    find-cache-dir: "npm:^2.0.0"
+    make-dir: "npm:^2.1.0"
+    pirates: "npm:^4.0.5"
+    source-map-support: "npm:^0.5.16"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: e66100046daa1dee8bed8322d17f8374b47d3b30945accd3761303ca7bf93db406cea5edd530684b4964dbf969c1b5d0aaea07ecf5146ee68cf0fee6b1de88b5
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
+  version: 7.18.9
+  resolution: "@babel/runtime@npm:7.18.9"
+  dependencies:
+    regenerator-runtime: "npm:^0.13.4"
+  checksum: 1581271f6f303662c74e992fc52aaaaa6119eb74ebff5328ff6998a7058795d442d19a5585faa43e344c4e7d48677faf94184a139b5941254069bc0ee579e467
   languageName: node
   linkType: hard
 
@@ -218,7 +1517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.18.6":
+"@babel/template@npm:^7.12.7, @babel/template@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/template@npm:7.18.6"
   dependencies:
@@ -229,7 +1528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.18.9":
+"@babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.12.11, @babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.4.5":
   version: 7.18.9
   resolution: "@babel/traverse@npm:7.18.9"
   dependencies:
@@ -247,13 +1546,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.12.6, @babel/types@npm:^7.17.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.12.11, @babel/types@npm:^7.12.7, @babel/types@npm:^7.17.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.2.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.18.9
   resolution: "@babel/types@npm:7.18.9"
   dependencies:
     "@babel/helper-validator-identifier": "npm:^7.18.6"
     to-fast-properties: "npm:^2.0.0"
   checksum: 720afa80ac35c23f97d9c0580836b36eff4155a29b64266de2586d59bb55e9ad4df9109b8c2a0ced1467a672e5af4d6d118bfa91609e1da0f12a6e930ccae0cd
+  languageName: node
+  linkType: hard
+
+"@base2/pretty-print-object@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@base2/pretty-print-object@npm:1.0.1"
+  checksum: f62354bc9155933ff93a521ea748a6e6799ff071a7b4989dc32a5f7be5aaade5c41d4efc8f3fcf7d69295ceb14f1690e3c4306c4af4bcfa8a99b5b702b4c134c
+  languageName: node
+  linkType: hard
+
+"@bcoe/v8-coverage@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@bcoe/v8-coverage@npm:0.2.3"
+  checksum: 86336400d6fb1a8263a3e7242ad7ed870f5efae7cd8c2b18df45fa11adc9af035bac68c0da68c0f67e78b3f09ef49efe2e84c4912ddc48e2d12f30ec474c81cc
+  languageName: node
+  linkType: hard
+
+"@colors/colors@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@colors/colors@npm:1.5.0"
+  checksum: 5e08870799494f68e5b3b79e9a337bbf5fd7e634904fbbe642769921bf158fe458c41c888f88edf051b78c5325e3339970f00b24e31421c3480bb58f02687218
   languageName: node
   linkType: hard
 
@@ -446,15 +1766,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cspell/cspell-bundled-dicts@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "@cspell/cspell-bundled-dicts@npm:6.4.1"
+"@cspell/cspell-bundled-dicts@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@cspell/cspell-bundled-dicts@npm:6.4.2"
   dependencies:
-    "@cspell/dict-ada": "npm:^2.0.0"
+    "@cspell/dict-ada": "npm:^2.0.1"
     "@cspell/dict-aws": "npm:^2.0.0"
     "@cspell/dict-bash": "npm:^2.0.4"
     "@cspell/dict-companies": "npm:^2.0.7"
-    "@cspell/dict-cpp": "npm:^3.2.0"
+    "@cspell/dict-cpp": "npm:^3.2.1"
     "@cspell/dict-cryptocurrencies": "npm:^2.0.0"
     "@cspell/dict-csharp": "npm:^3.0.1"
     "@cspell/dict-css": "npm:^2.0.0"
@@ -465,7 +1785,7 @@ __metadata:
     "@cspell/dict-elixir": "npm:^2.0.1"
     "@cspell/dict-en-gb": "npm:^1.1.33"
     "@cspell/dict-en_us": "npm:^2.3.0"
-    "@cspell/dict-filetypes": "npm:^2.1.0"
+    "@cspell/dict-filetypes": "npm:^2.1.1"
     "@cspell/dict-fonts": "npm:^2.0.1"
     "@cspell/dict-fullstack": "npm:^2.0.6"
     "@cspell/dict-git": "npm:^1.0.1"
@@ -478,38 +1798,39 @@ __metadata:
     "@cspell/dict-lorem-ipsum": "npm:^2.0.0"
     "@cspell/dict-lua": "npm:^2.0.0"
     "@cspell/dict-node": "npm:^3.0.1"
-    "@cspell/dict-npm": "npm:^3.0.1"
+    "@cspell/dict-npm": "npm:^3.1.0"
     "@cspell/dict-php": "npm:^2.0.0"
     "@cspell/dict-powershell": "npm:^2.0.0"
     "@cspell/dict-public-licenses": "npm:^1.0.5"
     "@cspell/dict-python": "npm:^3.0.6"
     "@cspell/dict-r": "npm:^1.0.3"
-    "@cspell/dict-ruby": "npm:^2.0.1"
+    "@cspell/dict-ruby": "npm:^2.0.2"
     "@cspell/dict-rust": "npm:^2.0.1"
     "@cspell/dict-scala": "npm:^2.0.0"
-    "@cspell/dict-software-terms": "npm:^2.1.12"
+    "@cspell/dict-software-terms": "npm:^2.2.0"
+    "@cspell/dict-sql": "npm:^1.0.3"
     "@cspell/dict-swift": "npm:^1.0.3"
     "@cspell/dict-typescript": "npm:^2.0.1"
     "@cspell/dict-vue": "npm:^2.0.2"
-  checksum: 77bb44849529c2e2ee3354c9b902eae61bb20a91ec11255f55ec7606a1c0e0890d70fe649bd83d5bb75abbde9fb366d0d2732368b72c2287c7712b55f75b0368
+  checksum: 9c0623710d2d99c6e530ef7e7ee16c132f4bb2d57c97fb3c9e935a09fcbaa1e0a0453d6d582d489e4f0f368aa96d718b9c692d1b99a0a8b98c3fac12a7f64f64
   languageName: node
   linkType: hard
 
-"@cspell/cspell-pipe@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "@cspell/cspell-pipe@npm:6.4.1"
-  checksum: 9d319a15adfaf7a08cb357acf74eb01ad142539f0179cfa2444fd1aed5d70bdd9177f0ddf7c1aa1c3bcdb1de0bb3cb71630f37b7065d020c5991b12ef7d20f4a
+"@cspell/cspell-pipe@npm:^6.4.1, @cspell/cspell-pipe@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@cspell/cspell-pipe@npm:6.4.2"
+  checksum: d9d5876766e7a487bae341a1d1359734058c006806e0c7c9d7ae1d4c5cf467e2fb3400b1f934ea85022751dd02e43e3cd5c5b1fdc15111ba3448899f670190ac
   languageName: node
   linkType: hard
 
-"@cspell/cspell-types@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "@cspell/cspell-types@npm:6.4.1"
-  checksum: 866a69c925b4a287cf5e5714fef168f21945359ca7e956eefd1894f455eb71fb7c0619d19e034dbfed26ce8d37ebdda0a08e8f2ee90f4611f2b76cf745d49d44
+"@cspell/cspell-types@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@cspell/cspell-types@npm:6.4.2"
+  checksum: 81aeef4e69acd2dd0c87a68fb948191bc96b839c69c21698627692ba90e684c21fd09bc0f162d0d9ffd951eefa6404d82ac088e412b868365e17413b7670751a
   languageName: node
   linkType: hard
 
-"@cspell/dict-ada@npm:^2.0.0":
+"@cspell/dict-ada@npm:^2.0.1":
   version: 2.0.1
   resolution: "@cspell/dict-ada@npm:2.0.1"
   checksum: 59774958c4dfd24c38d55cd8475e78462a26ca563b6b8e15cca3cbd8e31a43b937768c24683a9a1300413e508965558c4c7122052adb763fa99687e4f17e6c89
@@ -531,13 +1852,13 @@ __metadata:
   linkType: hard
 
 "@cspell/dict-companies@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@cspell/dict-companies@npm:2.0.7"
-  checksum: 41ffc3040447d7ffbb34203a7a1d9dc7f2a6b208d7be10a93ea585d8a179e178fc22bc28a6e5df6847b7237913e992b7803f377d439cd0d7386ffc2c66472bee
+  version: 2.0.9
+  resolution: "@cspell/dict-companies@npm:2.0.9"
+  checksum: ee38db1579fb1fae2355a7f84f52b7f95edcffd93d7874943a445d616ca65c3b60a4356475880bb336321119967caeec220c34aaba0522c8a1e50100b66f4b94
   languageName: node
   linkType: hard
 
-"@cspell/dict-cpp@npm:^3.2.0":
+"@cspell/dict-cpp@npm:^3.2.1":
   version: 3.2.1
   resolution: "@cspell/dict-cpp@npm:3.2.1"
   checksum: eea243cb31521207218b39c3c66b6a3728e1ed80b1161d24a563192b4f6c7336b5718f16124df0cd88b73ed73b2ce987ed5896be8284ab1f83beec6f0c7241f8
@@ -614,7 +1935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cspell/dict-filetypes@npm:^2.1.0":
+"@cspell/dict-filetypes@npm:^2.1.1":
   version: 2.1.1
   resolution: "@cspell/dict-filetypes@npm:2.1.1"
   checksum: 58ef10f906b3118ad3ad65152de3c1631a85c0cb66493e4ea64e5cc65ed1c091d7207dabd9f4e4cdb02337cb9c10c107e3c11fb66223404d77c65680a8f7751a
@@ -705,7 +2026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cspell/dict-npm@npm:^3.0.1":
+"@cspell/dict-npm@npm:^3.1.0":
   version: 3.1.0
   resolution: "@cspell/dict-npm@npm:3.1.0"
   checksum: c8b81c68b258cfd59c49beaccb94ab6d8951d19b30135e6032f438962bfd0710ff3acd15e3f06d9b67649e7f55da9781b029209d2f4ec1e357f66c7bc574e804
@@ -747,7 +2068,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cspell/dict-ruby@npm:^2.0.1":
+"@cspell/dict-ruby@npm:^2.0.2":
   version: 2.0.2
   resolution: "@cspell/dict-ruby@npm:2.0.2"
   checksum: 7fdd65ad1bcfb6e0bb00e104013683636b5abcc2598f01c7ab21d96505cef547987fb1b3286471b9507b028c0b9fe2fefbdf0e969b8fddfd3980e23d4651bb03
@@ -768,10 +2089,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cspell/dict-software-terms@npm:^2.1.12":
-  version: 2.2.0
-  resolution: "@cspell/dict-software-terms@npm:2.2.0"
-  checksum: cdb0c0c2079a2cc7798c82df7e9746077601e254b9c98bf4f8cf71f64bc8d3c4d65d1c6a292ce328d858f769a3f0827c1ef3122fc110b8087c4c22dc533299cd
+"@cspell/dict-software-terms@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "@cspell/dict-software-terms@npm:2.2.1"
+  checksum: c98b747bb56a1ce21c3f7c9ad65e53004ab4373b95cda73bf0df6b15a7e51c823fc3b657a149f7b70b70ff5d53e4668f237a13baae1fbf532fe13978e71ff3ba
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-sql@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "@cspell/dict-sql@npm:1.0.4"
+  checksum: def31e2728c9a8084d37d9fdebbe3fd27da97c1b1d8cc3437c2f5127c168fa011ad3cb2d8dc5f15ebcfaf763ae189fd87076172209a113197f2a731133b7e446
   languageName: node
   linkType: hard
 
@@ -809,6 +2137,43 @@ __metadata:
   version: 1.0.0
   resolution: "@cush/relative@npm:1.0.0"
   checksum: a4aeb4fd1bf46ee509e0314f72bac4329b39a1e8a2331b1451fa2fb32e0915f87f7bd5d891f3f35cd3c5cea323062c9f1b070eafe9207f4144e0894330d3267b
+  languageName: node
+  linkType: hard
+
+"@discoveryjs/json-ext@npm:^0.5.3":
+  version: 0.5.7
+  resolution: "@discoveryjs/json-ext@npm:0.5.7"
+  checksum: b6e8ff9be2e0b505f3e06379743f55d04028adbb0170dc191ff020f6e43f86f712e6cceb8a95db7e2c13a7dc6d7419f6b65af353ce662bf520e065b69e232ef7
+  languageName: node
+  linkType: hard
+
+"@emotion/is-prop-valid@npm:^1.1.0":
+  version: 1.1.3
+  resolution: "@emotion/is-prop-valid@npm:1.1.3"
+  dependencies:
+    "@emotion/memoize": "npm:^0.7.4"
+  checksum: 4bfc33b7e0dae657226e7cc40d6e759a046666acab2def08aa975c250b1a52aadd500913ba66dc3d4b7ae33b47032721cf14bc5ae920ce8e3174715dde77fb7a
+  languageName: node
+  linkType: hard
+
+"@emotion/memoize@npm:^0.7.4":
+  version: 0.7.5
+  resolution: "@emotion/memoize@npm:0.7.5"
+  checksum: da7b8c95e9e18f2f7a642aa4401a88f209d144df902c7a634694f7f844e5d47686a48f03299b857c4b305ccabadecf6ba5ce17a5d7c9af555f192d9a3d7fa96e
+  languageName: node
+  linkType: hard
+
+"@emotion/stylis@npm:^0.8.4":
+  version: 0.8.5
+  resolution: "@emotion/stylis@npm:0.8.5"
+  checksum: 0368ecbfbe358fa2f9ed9f2b550da23a50e92661c706df744e3d586e1c3db7cb2de96cc324659b2678c17ab30d7be0c53bb54b9a6fc0326f3bdc4991edd48724
+  languageName: node
+  linkType: hard
+
+"@emotion/unitless@npm:^0.7.4":
+  version: 0.7.5
+  resolution: "@emotion/unitless@npm:0.7.5"
+  checksum: 7d85f5dfc8b5b394e3a0c35400ba96afb4e6160473f5e0a88d2b5eb3657b69341c65a5f4913f5a61b578ce4a210247f484b947af3f44f7ebeb6d936956652e14
   languageName: node
   linkType: hard
 
@@ -866,19 +2231,22 @@ __metadata:
     "@commitlint/types": "npm:17.0.0"
     "@faker-js/faker": "npm:7.3.0"
     "@flex-development/tutils": "npm:4.8.0"
+    "@rollup/pluginutils": "npm:4.2.1"
+    "@storybook/react": "npm:6.5.9"
     "@types/chai": "npm:4.3.1"
     "@types/eslint": "npm:8.4.5"
     "@types/is-ci": "npm:3.0.0"
-    "@types/micromatch": "npm:4.0.2"
     "@types/mvdan-sh": "npm:0.5.1"
     "@types/node": "npm:16.11.45"
     "@types/node-notifier": "npm:8.0.2"
     "@types/prettier": "npm:2.6.3"
     "@types/react": "npm:18.0.15"
+    "@types/styled-components": "npm:5.1.25"
     "@typescript-eslint/eslint-plugin": "npm:5.31.0"
     "@typescript-eslint/parser": "npm:5.31.0"
     "@vates/toggle-scripts": "npm:1.0.0"
     "@vitest/ui": "npm:0.19.1"
+    c8: "npm:7.12.0"
     chai: "npm:4.3.6"
     cspell: "npm:6.4.1"
     eslint: "npm:8.20.0"
@@ -901,7 +2269,6 @@ __metadata:
     jsonc-eslint-parser: "npm:2.1.0"
     lint-staged: "npm:13.0.3"
     magic-string: "npm:0.26.2"
-    micromatch: "npm:4.0.5"
     node-notifier: "npm:10.0.1"
     prettier: "npm:2.7.1"
     prettier-plugin-sh: "npm:0.12.6"
@@ -909,6 +2276,8 @@ __metadata:
     react: "npm:18.2.0"
     react-docgen-typescript: "npm:2.2.2"
     resolve-tspaths: "npm:0.7.1"
+    styled-components: "npm:5.3.5"
+    telejson: "npm:6.0.8"
     trash-cli: "npm:5.0.0"
     ts-dedent: "npm:2.2.0"
     ts-node: "npm:10.9.1"
@@ -918,7 +2287,6 @@ __metadata:
     vite: "npm:3.0.3"
     vite-plugin-inspect: "npm:0.6.0"
     vite-tsconfig-paths: "npm:3.5.0"
-    viteshot: "npm:0.3.1"
     vitest: "npm:0.19.1"
     vitest-github-actions-reporter: "npm:0.8.1"
     yaml-eslint-parser: "npm:1.0.1"
@@ -927,7 +2295,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gar/promisify@npm:^1.1.3":
+"@gar/promisify@npm:^1.0.1, @gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
   checksum: 3fadc40481a783ddb90397f5759f92650b57465f7a4a778056bd24b47060595012e9181a55ae547d57a893d37d9776abe9e368f1f6918e37225eb6a83f9a75f8
@@ -952,6 +2320,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@istanbuljs/schema@npm:^0.1.2, @istanbuljs/schema@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@istanbuljs/schema@npm:0.1.3"
+  checksum: 1f6fd298c4d287b8c1ba55ab0cec14b4006c3f7aa032fe09a82f3322d943fd8aa9aa5691ad2e1c0c8693d42546c2cfa6adb45d09e2131fb5b975f7caab6aa5d8
+  languageName: node
+  linkType: hard
+
 "@jest/schemas@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/schemas@npm:28.1.3"
@@ -971,7 +2346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.2":
+"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2":
   version: 0.3.2
   resolution: "@jridgewell/gen-mapping@npm:0.3.2"
   dependencies:
@@ -996,6 +2371,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/source-map@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@jridgewell/source-map@npm:0.3.2"
+  dependencies:
+    "@jridgewell/gen-mapping": "npm:^0.3.0"
+    "@jridgewell/trace-mapping": "npm:^0.3.9"
+  checksum: 66bb5d5cac95793717fea6cfe45c02c0e493f39c320cdaee030a39de033a961cfcb2f5bf105150eb8fada65b6654e72e33efae35349fbaca897414a17c984c34
+  languageName: node
+  linkType: hard
+
 "@jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
@@ -1013,7 +2398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.9":
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.7, @jridgewell/trace-mapping@npm:^0.3.9":
   version: 0.3.14
   resolution: "@jridgewell/trace-mapping@npm:0.3.14"
   dependencies:
@@ -1023,19 +2408,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kwsites/file-exists@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@kwsites/file-exists@npm:1.1.1"
+"@mdx-js/mdx@npm:^1.6.22":
+  version: 1.6.22
+  resolution: "@mdx-js/mdx@npm:1.6.22"
   dependencies:
-    debug: "npm:^4.1.1"
-  checksum: 81832dce08e5bed62d54baa9b20f2107b1a442efcbf9e0c2726ac754d19757edeedcdf57b252af970b44cb7623a434240d659d2ac6b8bf41c5b99d6eba89b475
+    "@babel/core": "npm:7.12.9"
+    "@babel/plugin-syntax-jsx": "npm:7.12.1"
+    "@babel/plugin-syntax-object-rest-spread": "npm:7.8.3"
+    "@mdx-js/util": "npm:1.6.22"
+    babel-plugin-apply-mdx-type-prop: "npm:1.6.22"
+    babel-plugin-extract-import-names: "npm:1.6.22"
+    camelcase-css: "npm:2.0.1"
+    detab: "npm:2.0.4"
+    hast-util-raw: "npm:6.0.1"
+    lodash.uniq: "npm:4.5.0"
+    mdast-util-to-hast: "npm:10.0.1"
+    remark-footnotes: "npm:2.0.0"
+    remark-mdx: "npm:1.6.22"
+    remark-parse: "npm:8.0.3"
+    remark-squeeze-paragraphs: "npm:4.0.0"
+    style-to-object: "npm:0.3.0"
+    unified: "npm:9.2.0"
+    unist-builder: "npm:2.0.3"
+    unist-util-visit: "npm:2.0.3"
+  checksum: 77ddf5fea57d962aad0e8f2be26df286041dc4318f5fbe1997bb4b8225c611d9eff63ba1bb239e31d4cf833a4bb6d8313bd2eed41a7a1cd0f1c179a53ef09bbf
   languageName: node
   linkType: hard
 
-"@kwsites/promise-deferred@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@kwsites/promise-deferred@npm:1.1.1"
-  checksum: d8eab06cdd466e40932201707dd332ef666a743ccbbbb21ac4d4ac8563c3ce62c1b748bbdd7e3755da2c19fdea47253d332c489980aecdf278cfa87b4785dad0
+"@mdx-js/util@npm:1.6.22":
+  version: 1.6.22
+  resolution: "@mdx-js/util@npm:1.6.22"
+  checksum: e79ab0bd03651007ea325e2a6fd44dbb75fc74f14b98431747760f3274f3f45385cd3265dc79d7e6009b2e1d27e68ca2a49ff3d193a05b8693289c4bd9412e3f
+  languageName: node
+  linkType: hard
+
+"@mrmlnc/readdir-enhanced@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@mrmlnc/readdir-enhanced@npm:2.2.1"
+  dependencies:
+    call-me-maybe: "npm:^1.0.1"
+    glob-to-regexp: "npm:^0.3.0"
+  checksum: c93235d49360e8a1369662f7101b9c15b4a1551c81b25028bcbed35ad1273f71d64eb3744cb04f1d425685010216f6a0e6f2ad7fd846cb169a5d6b26db61bfdb
   languageName: node
   linkType: hard
 
@@ -1056,6 +2469,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nodelib/fs.stat@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "@nodelib/fs.stat@npm:1.1.3"
+  checksum: d4797bcb5a64cf20afb8b2b58b5fb74f8d78272ab9b0f2b571245b941ae4a419474ac5fbfd9826dbb6b3ba99853608efc3729ca1c85872107e04ca612535759d
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.walk@npm:^1.2.3":
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
@@ -1063,6 +2483,16 @@ __metadata:
     "@nodelib/fs.scandir": "npm:2.1.5"
     fastq: "npm:^1.6.0"
   checksum: 3542284aa2d6e313cfd4ae40a2502b53e1f35da6f4f9890422aad018c04866f6bfb96c4105e23dbd9fb93cfc630cc607777df658a3a525d63a3bfb9bcb2b0f21
+  languageName: node
+  linkType: hard
+
+"@npmcli/fs@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "@npmcli/fs@npm:1.1.1"
+  dependencies:
+    "@gar/promisify": "npm:^1.0.1"
+    semver: "npm:^7.3.5"
+  checksum: 698d480c656a9c5dab9bf1c07c9709576a5ce2947521dea24bff674ad2013fd9cf690fce54298df7ebc32f8234448c17d9785ccd92afbaf001a6754c27fe6695
   languageName: node
   linkType: hard
 
@@ -1076,6 +2506,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/move-file@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "@npmcli/move-file@npm:1.1.2"
+  dependencies:
+    mkdirp: "npm:^1.0.4"
+    rimraf: "npm:^3.0.2"
+  checksum: 6fdcd5e51041da8d3d84f6ba89ff290900bf3adb736816c4b441b1fc8a41045db7253860c54a4ccdeb0e84e1c9548551bfb893f7392423de752a016a2a16952a
+  languageName: node
+  linkType: hard
+
 "@npmcli/move-file@npm:^2.0.0":
   version: 2.0.0
   resolution: "@npmcli/move-file@npm:2.0.0"
@@ -1083,6 +2523,45 @@ __metadata:
     mkdirp: "npm:^1.0.4"
     rimraf: "npm:^3.0.2"
   checksum: e7c413d3ed558183dd32b88bd024fa71f152267f2172211e1bb3ef60caf86cb438e4365b02affdd633ca4600eeb1d6143a454ccffc2aa84e468e56074a6cc7e7
+  languageName: node
+  linkType: hard
+
+"@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.3":
+  version: 0.5.7
+  resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.5.7"
+  dependencies:
+    ansi-html-community: "npm:^0.0.8"
+    common-path-prefix: "npm:^3.0.0"
+    core-js-pure: "npm:^3.8.1"
+    error-stack-parser: "npm:^2.0.6"
+    find-up: "npm:^5.0.0"
+    html-entities: "npm:^2.1.0"
+    loader-utils: "npm:^2.0.0"
+    schema-utils: "npm:^3.0.0"
+    source-map: "npm:^0.7.3"
+  peerDependencies:
+    "@types/webpack": 4.x || 5.x
+    react-refresh: ">=0.10.0 <1.0.0"
+    sockjs-client: ^1.4.0
+    type-fest: ">=0.17.0 <3.0.0"
+    webpack: ">=4.43.0 <6.0.0"
+    webpack-dev-server: 3.x || 4.x
+    webpack-hot-middleware: 2.x
+    webpack-plugin-serve: 0.x || 1.x
+  peerDependenciesMeta:
+    "@types/webpack":
+      optional: true
+    sockjs-client:
+      optional: true
+    type-fest:
+      optional: true
+    webpack-dev-server:
+      optional: true
+    webpack-hot-middleware:
+      optional: true
+    webpack-plugin-serve:
+      optional: true
+  checksum: c92917d83f6350365ded4d5d43fd3b76723248c4ae295c833e6220556d82a1596b7c9f3f38ac8da304d2096042700e4d1f74561b9f3a8494151a6fcec0a4d9db
   languageName: node
   linkType: hard
 
@@ -1160,6 +2639,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/pluginutils@npm:4.2.1, @rollup/pluginutils@npm:^4.1.1, @rollup/pluginutils@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@rollup/pluginutils@npm:4.2.1"
+  dependencies:
+    estree-walker: "npm:^2.0.1"
+    picomatch: "npm:^2.2.2"
+  checksum: 96f7c2ec2ca7f20178c65a6634a1d612fc3ff6d4a70ff18468d1a909218d491f0164c320dbf195fbbf932059e71c21cfa31b64813d7922f14c83e773527f8b8e
+  languageName: node
+  linkType: hard
+
 "@rollup/pluginutils@npm:^3.0.8, @rollup/pluginutils@npm:^3.1.0":
   version: 3.1.0
   resolution: "@rollup/pluginutils@npm:3.1.0"
@@ -1173,20 +2662,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^4.1.1, @rollup/pluginutils@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "@rollup/pluginutils@npm:4.2.1"
-  dependencies:
-    estree-walker: "npm:^2.0.1"
-    picomatch: "npm:^2.2.2"
-  checksum: 96f7c2ec2ca7f20178c65a6634a1d612fc3ff6d4a70ff18468d1a909218d491f0164c320dbf195fbbf932059e71c21cfa31b64813d7922f14c83e773527f8b8e
-  languageName: node
-  linkType: hard
-
 "@sinclair/typebox@npm:^0.24.1":
-  version: 0.24.20
-  resolution: "@sinclair/typebox@npm:0.24.20"
-  checksum: 1bb0c1e9cb908b18455477ff74006bd011297cf23dd615644187e5daacc7176e6acaf2f3c499a8a8ac9dc15ab8d9f52c7f9a73cac312a855da22c91c0c1d497f
+  version: 0.24.21
+  resolution: "@sinclair/typebox@npm:0.24.21"
+  checksum: e1e221f0b495e845b0bb0fee7665595a1306683a8627a200d63fb9ea21aa29d662baee0a328ca29312125ba05f8d1e6dc97ded8b582b7906f5d550f5b407701d
   languageName: node
   linkType: hard
 
@@ -1213,114 +2692,770 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addons@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/addons@npm:6.5.9"
+  dependencies:
+    "@storybook/api": "npm:6.5.9"
+    "@storybook/channels": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/router": "npm:6.5.9"
+    "@storybook/theming": "npm:6.5.9"
+    "@types/webpack-env": "npm:^1.16.0"
+    core-js: "npm:^3.8.2"
+    global: "npm:^4.4.0"
+    regenerator-runtime: "npm:^0.13.7"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: ecf2b39fea935b25080c924cf30acd48990aa95ee14fac66c1e3db5a6a26eb637863d04cac0658fb7f6c0d03ae9b6b304b725a9b0282b9da5bae7cf1ff59434e
+  languageName: node
+  linkType: hard
+
+"@storybook/api@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/api@npm:6.5.9"
+  dependencies:
+    "@storybook/channels": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/router": "npm:6.5.9"
+    "@storybook/semver": "npm:^7.3.2"
+    "@storybook/theming": "npm:6.5.9"
+    core-js: "npm:^3.8.2"
+    fast-deep-equal: "npm:^3.1.3"
+    global: "npm:^4.4.0"
+    lodash: "npm:^4.17.21"
+    memoizerific: "npm:^1.11.3"
+    regenerator-runtime: "npm:^0.13.7"
+    store2: "npm:^2.12.0"
+    telejson: "npm:^6.0.8"
+    ts-dedent: "npm:^2.0.0"
+    util-deprecate: "npm:^1.0.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: e721cc02431c399af79592aa4b2ebfa21e057f3e32dd8d7a6afadf4ce2dc3fa8644475442b57fd1bed88db5c24f0364a818e17dd70c5ba024618a4fc31e247a5
+  languageName: node
+  linkType: hard
+
+"@storybook/builder-webpack4@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/builder-webpack4@npm:6.5.9"
+  dependencies:
+    "@babel/core": "npm:^7.12.10"
+    "@storybook/addons": "npm:6.5.9"
+    "@storybook/api": "npm:6.5.9"
+    "@storybook/channel-postmessage": "npm:6.5.9"
+    "@storybook/channels": "npm:6.5.9"
+    "@storybook/client-api": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/components": "npm:6.5.9"
+    "@storybook/core-common": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    "@storybook/node-logger": "npm:6.5.9"
+    "@storybook/preview-web": "npm:6.5.9"
+    "@storybook/router": "npm:6.5.9"
+    "@storybook/semver": "npm:^7.3.2"
+    "@storybook/store": "npm:6.5.9"
+    "@storybook/theming": "npm:6.5.9"
+    "@storybook/ui": "npm:6.5.9"
+    "@types/node": "npm:^14.0.10 || ^16.0.0"
+    "@types/webpack": "npm:^4.41.26"
+    autoprefixer: "npm:^9.8.6"
+    babel-loader: "npm:^8.0.0"
+    case-sensitive-paths-webpack-plugin: "npm:^2.3.0"
+    core-js: "npm:^3.8.2"
+    css-loader: "npm:^3.6.0"
+    file-loader: "npm:^6.2.0"
+    find-up: "npm:^5.0.0"
+    fork-ts-checker-webpack-plugin: "npm:^4.1.6"
+    glob: "npm:^7.1.6"
+    glob-promise: "npm:^3.4.0"
+    global: "npm:^4.4.0"
+    html-webpack-plugin: "npm:^4.0.0"
+    pnp-webpack-plugin: "npm:1.6.4"
+    postcss: "npm:^7.0.36"
+    postcss-flexbugs-fixes: "npm:^4.2.1"
+    postcss-loader: "npm:^4.2.0"
+    raw-loader: "npm:^4.0.2"
+    stable: "npm:^0.1.8"
+    style-loader: "npm:^1.3.0"
+    terser-webpack-plugin: "npm:^4.2.3"
+    ts-dedent: "npm:^2.0.0"
+    url-loader: "npm:^4.1.1"
+    util-deprecate: "npm:^1.0.2"
+    webpack: "npm:4"
+    webpack-dev-middleware: "npm:^3.7.3"
+    webpack-filter-warnings-plugin: "npm:^1.2.1"
+    webpack-hot-middleware: "npm:^2.25.1"
+    webpack-virtual-modules: "npm:^0.2.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 74a2edd523afb28d59b58a3867331b8c84529e48ef2489da265292e7a63192c174fe32267768244a9cbd6fe06922ebe9da109817e846455a0664b5c06181f34a
+  languageName: node
+  linkType: hard
+
+"@storybook/channel-postmessage@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/channel-postmessage@npm:6.5.9"
+  dependencies:
+    "@storybook/channels": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    core-js: "npm:^3.8.2"
+    global: "npm:^4.4.0"
+    qs: "npm:^6.10.0"
+    telejson: "npm:^6.0.8"
+  checksum: f273f19ce86573d8cdf1132cfffc48935f95f6cfbb5e792dd664f260a029314b9045e9538f528ee761eedcf801d9069c564c7dada144040b26706c8c7536dbff
+  languageName: node
+  linkType: hard
+
+"@storybook/channel-websocket@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/channel-websocket@npm:6.5.9"
+  dependencies:
+    "@storybook/channels": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    core-js: "npm:^3.8.2"
+    global: "npm:^4.4.0"
+    telejson: "npm:^6.0.8"
+  checksum: eef4252efdf0c8dafd96af7c5f51544c95f728377abcaed07edae2d3b8cc950acb25c1d0c3d0c4a9d9a8441f165d475a9f7357e07d77f772005f798c3074dc9e
+  languageName: node
+  linkType: hard
+
+"@storybook/channels@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/channels@npm:6.5.9"
+  dependencies:
+    core-js: "npm:^3.8.2"
+    ts-dedent: "npm:^2.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 4452ab1ee37c93dd0c44d89eb8af76b4fd52483b69645db9da2e6f940fd83633af180f10d53cebe761154bb1cfcc458d1c818f30288834edc961b913b812289b
+  languageName: node
+  linkType: hard
+
+"@storybook/client-api@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/client-api@npm:6.5.9"
+  dependencies:
+    "@storybook/addons": "npm:6.5.9"
+    "@storybook/channel-postmessage": "npm:6.5.9"
+    "@storybook/channels": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/store": "npm:6.5.9"
+    "@types/qs": "npm:^6.9.5"
+    "@types/webpack-env": "npm:^1.16.0"
+    core-js: "npm:^3.8.2"
+    fast-deep-equal: "npm:^3.1.3"
+    global: "npm:^4.4.0"
+    lodash: "npm:^4.17.21"
+    memoizerific: "npm:^1.11.3"
+    qs: "npm:^6.10.0"
+    regenerator-runtime: "npm:^0.13.7"
+    store2: "npm:^2.12.0"
+    synchronous-promise: "npm:^2.0.15"
+    ts-dedent: "npm:^2.0.0"
+    util-deprecate: "npm:^1.0.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: bd22d52a0808cee9f91408947311ff2cf84335a0aafd1451e42a682c3fb4973a3b23c1d99b647b2c2038dd645c3525caf05d35a2b63898cd1a089cc2f52bd071
+  languageName: node
+  linkType: hard
+
+"@storybook/client-logger@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/client-logger@npm:6.5.9"
+  dependencies:
+    core-js: "npm:^3.8.2"
+    global: "npm:^4.4.0"
+  checksum: 0f47bdc172c95e57f893f20039daab1f0c1581d8b8dddf72d34340e6881e5f887db0deb9a1e3b03670c7535599519ae64cf1d0c58ea69f07174f9250200cecfb
+  languageName: node
+  linkType: hard
+
+"@storybook/components@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/components@npm:6.5.9"
+  dependencies:
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/theming": "npm:6.5.9"
+    "@types/react-syntax-highlighter": "npm:11.0.5"
+    core-js: "npm:^3.8.2"
+    memoizerific: "npm:^1.11.3"
+    qs: "npm:^6.10.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    regenerator-runtime: "npm:^0.13.7"
+    util-deprecate: "npm:^1.0.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 1bdec40de71359eaecfc630d849e5fdc1b88af16d9367eeb3c52cad84ef5efdbab0eefa54e4eb9544f7f21df5ebf5c5d0c4be0ffa1a795aac38888f47c6b69d9
+  languageName: node
+  linkType: hard
+
+"@storybook/core-client@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/core-client@npm:6.5.9"
+  dependencies:
+    "@storybook/addons": "npm:6.5.9"
+    "@storybook/channel-postmessage": "npm:6.5.9"
+    "@storybook/channel-websocket": "npm:6.5.9"
+    "@storybook/client-api": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/preview-web": "npm:6.5.9"
+    "@storybook/store": "npm:6.5.9"
+    "@storybook/ui": "npm:6.5.9"
+    airbnb-js-shims: "npm:^2.2.1"
+    ansi-to-html: "npm:^0.6.11"
+    core-js: "npm:^3.8.2"
+    global: "npm:^4.4.0"
+    lodash: "npm:^4.17.21"
+    qs: "npm:^6.10.0"
+    regenerator-runtime: "npm:^0.13.7"
+    ts-dedent: "npm:^2.0.0"
+    unfetch: "npm:^4.2.0"
+    util-deprecate: "npm:^1.0.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    webpack: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 8ced285148720d4c25517e2e6a60b38e48e45a539723edbc359340e7114db561db23711b82e641fa1ba985c4044b54db17b64a8a958334b2ab0414c52b708cbc
+  languageName: node
+  linkType: hard
+
+"@storybook/core-common@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/core-common@npm:6.5.9"
+  dependencies:
+    "@babel/core": "npm:^7.12.10"
+    "@babel/plugin-proposal-class-properties": "npm:^7.12.1"
+    "@babel/plugin-proposal-decorators": "npm:^7.12.12"
+    "@babel/plugin-proposal-export-default-from": "npm:^7.12.1"
+    "@babel/plugin-proposal-nullish-coalescing-operator": "npm:^7.12.1"
+    "@babel/plugin-proposal-object-rest-spread": "npm:^7.12.1"
+    "@babel/plugin-proposal-optional-chaining": "npm:^7.12.7"
+    "@babel/plugin-proposal-private-methods": "npm:^7.12.1"
+    "@babel/plugin-proposal-private-property-in-object": "npm:^7.12.1"
+    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
+    "@babel/plugin-transform-arrow-functions": "npm:^7.12.1"
+    "@babel/plugin-transform-block-scoping": "npm:^7.12.12"
+    "@babel/plugin-transform-classes": "npm:^7.12.1"
+    "@babel/plugin-transform-destructuring": "npm:^7.12.1"
+    "@babel/plugin-transform-for-of": "npm:^7.12.1"
+    "@babel/plugin-transform-parameters": "npm:^7.12.1"
+    "@babel/plugin-transform-shorthand-properties": "npm:^7.12.1"
+    "@babel/plugin-transform-spread": "npm:^7.12.1"
+    "@babel/preset-env": "npm:^7.12.11"
+    "@babel/preset-react": "npm:^7.12.10"
+    "@babel/preset-typescript": "npm:^7.12.7"
+    "@babel/register": "npm:^7.12.1"
+    "@storybook/node-logger": "npm:6.5.9"
+    "@storybook/semver": "npm:^7.3.2"
+    "@types/node": "npm:^14.0.10 || ^16.0.0"
+    "@types/pretty-hrtime": "npm:^1.0.0"
+    babel-loader: "npm:^8.0.0"
+    babel-plugin-macros: "npm:^3.0.1"
+    babel-plugin-polyfill-corejs3: "npm:^0.1.0"
+    chalk: "npm:^4.1.0"
+    core-js: "npm:^3.8.2"
+    express: "npm:^4.17.1"
+    file-system-cache: "npm:^1.0.5"
+    find-up: "npm:^5.0.0"
+    fork-ts-checker-webpack-plugin: "npm:^6.0.4"
+    fs-extra: "npm:^9.0.1"
+    glob: "npm:^7.1.6"
+    handlebars: "npm:^4.7.7"
+    interpret: "npm:^2.2.0"
+    json5: "npm:^2.1.3"
+    lazy-universal-dotenv: "npm:^3.0.1"
+    picomatch: "npm:^2.3.0"
+    pkg-dir: "npm:^5.0.0"
+    pretty-hrtime: "npm:^1.0.3"
+    resolve-from: "npm:^5.0.0"
+    slash: "npm:^3.0.0"
+    telejson: "npm:^6.0.8"
+    ts-dedent: "npm:^2.0.0"
+    util-deprecate: "npm:^1.0.2"
+    webpack: "npm:4"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: ead43837311ac779f37d1a1bf5687bd4fd437fd3ae6ec388a5779d2f222ea0f2564e9803458a8004ee02df37f36cdb7fc19762a7730f49f9971367fbe223129e
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/core-events@npm:6.5.9"
+  dependencies:
+    core-js: "npm:^3.8.2"
+  checksum: 0b26aa1492cc339021a6bdf65a8b6b54b6af6a8b5609d9f90d675f6b125b11094807e5f71ca281e847743bcca70c7496e6746f23d068bdadbe4f67792662c458
+  languageName: node
+  linkType: hard
+
+"@storybook/core-server@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/core-server@npm:6.5.9"
+  dependencies:
+    "@discoveryjs/json-ext": "npm:^0.5.3"
+    "@storybook/builder-webpack4": "npm:6.5.9"
+    "@storybook/core-client": "npm:6.5.9"
+    "@storybook/core-common": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/csf-tools": "npm:6.5.9"
+    "@storybook/manager-webpack4": "npm:6.5.9"
+    "@storybook/node-logger": "npm:6.5.9"
+    "@storybook/semver": "npm:^7.3.2"
+    "@storybook/store": "npm:6.5.9"
+    "@storybook/telemetry": "npm:6.5.9"
+    "@types/node": "npm:^14.0.10 || ^16.0.0"
+    "@types/node-fetch": "npm:^2.5.7"
+    "@types/pretty-hrtime": "npm:^1.0.0"
+    "@types/webpack": "npm:^4.41.26"
+    better-opn: "npm:^2.1.1"
+    boxen: "npm:^5.1.2"
+    chalk: "npm:^4.1.0"
+    cli-table3: "npm:^0.6.1"
+    commander: "npm:^6.2.1"
+    compression: "npm:^1.7.4"
+    core-js: "npm:^3.8.2"
+    cpy: "npm:^8.1.2"
+    detect-port: "npm:^1.3.0"
+    express: "npm:^4.17.1"
+    fs-extra: "npm:^9.0.1"
+    global: "npm:^4.4.0"
+    globby: "npm:^11.0.2"
+    ip: "npm:^2.0.0"
+    lodash: "npm:^4.17.21"
+    node-fetch: "npm:^2.6.7"
+    open: "npm:^8.4.0"
+    pretty-hrtime: "npm:^1.0.3"
+    prompts: "npm:^2.4.0"
+    regenerator-runtime: "npm:^0.13.7"
+    serve-favicon: "npm:^2.5.0"
+    slash: "npm:^3.0.0"
+    telejson: "npm:^6.0.8"
+    ts-dedent: "npm:^2.0.0"
+    util-deprecate: "npm:^1.0.2"
+    watchpack: "npm:^2.2.0"
+    webpack: "npm:4"
+    ws: "npm:^8.2.3"
+    x-default-browser: "npm:^0.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@storybook/builder-webpack5":
+      optional: true
+    "@storybook/manager-webpack5":
+      optional: true
+    typescript:
+      optional: true
+  checksum: b0eaabae95d7482db66deaff11a2687d284a30635927e3e4b6af4835dbe392c29a05198da210f2a2d8c3bc18dc7d487ff0866e7de62da368562fc459fa936b4c
+  languageName: node
+  linkType: hard
+
+"@storybook/core@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/core@npm:6.5.9"
+  dependencies:
+    "@storybook/core-client": "npm:6.5.9"
+    "@storybook/core-server": "npm:6.5.9"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    webpack: "*"
+  peerDependenciesMeta:
+    "@storybook/builder-webpack5":
+      optional: true
+    "@storybook/manager-webpack5":
+      optional: true
+    typescript:
+      optional: true
+  checksum: ecfec05a5b754b006676d5b13569f97ef456033b8eedef6d020f27deb857d2009d58b91bbcb14de3488ddae3204b0418bcb0795bdf1aa27c052234a95a42a2f2
+  languageName: node
+  linkType: hard
+
+"@storybook/csf-tools@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/csf-tools@npm:6.5.9"
+  dependencies:
+    "@babel/core": "npm:^7.12.10"
+    "@babel/generator": "npm:^7.12.11"
+    "@babel/parser": "npm:^7.12.11"
+    "@babel/plugin-transform-react-jsx": "npm:^7.12.12"
+    "@babel/preset-env": "npm:^7.12.11"
+    "@babel/traverse": "npm:^7.12.11"
+    "@babel/types": "npm:^7.12.11"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/mdx1-csf": "npm:^0.0.1"
+    core-js: "npm:^3.8.2"
+    fs-extra: "npm:^9.0.1"
+    global: "npm:^4.4.0"
+    regenerator-runtime: "npm:^0.13.7"
+    ts-dedent: "npm:^2.0.0"
+  peerDependencies:
+    "@storybook/mdx2-csf": ^0.0.3
+  peerDependenciesMeta:
+    "@storybook/mdx2-csf":
+      optional: true
+  checksum: e91488552c537e56170188a8ae8ca920064b035c927a730141bdd5e971d343663b9b610eec8be41ff2fb048cc3695ef308f179fe43cd01c450e5d7ad337440c0
+  languageName: node
+  linkType: hard
+
+"@storybook/csf@npm:0.0.2--canary.4566f4d.1":
+  version: 0.0.2--canary.4566f4d.1
+  resolution: "@storybook/csf@npm:0.0.2--canary.4566f4d.1"
+  dependencies:
+    lodash: "npm:^4.17.15"
+  checksum: 41b977c81d7cc897c5539c989eabe33bd7a0e9d3d2991fca8b3da67ff23382803c52c225c2364e2cafc07de5fec6f870dba1d9b7050be699541322ab61820550
+  languageName: node
+  linkType: hard
+
+"@storybook/docs-tools@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/docs-tools@npm:6.5.9"
+  dependencies:
+    "@babel/core": "npm:^7.12.10"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/store": "npm:6.5.9"
+    core-js: "npm:^3.8.2"
+    doctrine: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    regenerator-runtime: "npm:^0.13.7"
+  checksum: fde1e213befd99c3fb485ff193e469ad36167ee3c122bc53910d207ff23f948665d251eb5e01dc6880ee06907d76a97100c87a2450e328ca07295e638957d36f
+  languageName: node
+  linkType: hard
+
+"@storybook/manager-webpack4@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/manager-webpack4@npm:6.5.9"
+  dependencies:
+    "@babel/core": "npm:^7.12.10"
+    "@babel/plugin-transform-template-literals": "npm:^7.12.1"
+    "@babel/preset-react": "npm:^7.12.10"
+    "@storybook/addons": "npm:6.5.9"
+    "@storybook/core-client": "npm:6.5.9"
+    "@storybook/core-common": "npm:6.5.9"
+    "@storybook/node-logger": "npm:6.5.9"
+    "@storybook/theming": "npm:6.5.9"
+    "@storybook/ui": "npm:6.5.9"
+    "@types/node": "npm:^14.0.10 || ^16.0.0"
+    "@types/webpack": "npm:^4.41.26"
+    babel-loader: "npm:^8.0.0"
+    case-sensitive-paths-webpack-plugin: "npm:^2.3.0"
+    chalk: "npm:^4.1.0"
+    core-js: "npm:^3.8.2"
+    css-loader: "npm:^3.6.0"
+    express: "npm:^4.17.1"
+    file-loader: "npm:^6.2.0"
+    find-up: "npm:^5.0.0"
+    fs-extra: "npm:^9.0.1"
+    html-webpack-plugin: "npm:^4.0.0"
+    node-fetch: "npm:^2.6.7"
+    pnp-webpack-plugin: "npm:1.6.4"
+    read-pkg-up: "npm:^7.0.1"
+    regenerator-runtime: "npm:^0.13.7"
+    resolve-from: "npm:^5.0.0"
+    style-loader: "npm:^1.3.0"
+    telejson: "npm:^6.0.8"
+    terser-webpack-plugin: "npm:^4.2.3"
+    ts-dedent: "npm:^2.0.0"
+    url-loader: "npm:^4.1.1"
+    util-deprecate: "npm:^1.0.2"
+    webpack: "npm:4"
+    webpack-dev-middleware: "npm:^3.7.3"
+    webpack-virtual-modules: "npm:^0.2.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: f2489b1f00e3b15048f8d5e60e247b7fc7902663994c7a1d463d3562b0f54bc24122a5aac9e6b68fcc511009dc3a7603b447aa4ab910555fbb1c36668abf405d
+  languageName: node
+  linkType: hard
+
+"@storybook/mdx1-csf@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@storybook/mdx1-csf@npm:0.0.1"
+  dependencies:
+    "@babel/generator": "npm:^7.12.11"
+    "@babel/parser": "npm:^7.12.11"
+    "@babel/preset-env": "npm:^7.12.11"
+    "@babel/types": "npm:^7.12.11"
+    "@mdx-js/mdx": "npm:^1.6.22"
+    "@types/lodash": "npm:^4.14.167"
+    js-string-escape: "npm:^1.0.1"
+    loader-utils: "npm:^2.0.0"
+    lodash: "npm:^4.17.21"
+    prettier: "npm:>=2.2.1 <=2.3.0"
+    ts-dedent: "npm:^2.0.0"
+  checksum: a88c7d78f168bf635d877e7f2b9b8ce971ec8e3474f107afa3595685d65a4b24cd2df767f548d611b1a5efc3ff3d7f38c96d579902070b9fa53152cfec213f9e
+  languageName: node
+  linkType: hard
+
+"@storybook/node-logger@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/node-logger@npm:6.5.9"
+  dependencies:
+    "@types/npmlog": "npm:^4.1.2"
+    chalk: "npm:^4.1.0"
+    core-js: "npm:^3.8.2"
+    npmlog: "npm:^5.0.1"
+    pretty-hrtime: "npm:^1.0.3"
+  checksum: 02d9fc7752a9931f68584efd65a7b4d5a494c770d0af50554e8b3701216d538f26ffa4b32a73e6c56204d0f5ecf4a637155c526e62eca728ce6749d8cf4e2de1
+  languageName: node
+  linkType: hard
+
+"@storybook/preview-web@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/preview-web@npm:6.5.9"
+  dependencies:
+    "@storybook/addons": "npm:6.5.9"
+    "@storybook/channel-postmessage": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/store": "npm:6.5.9"
+    ansi-to-html: "npm:^0.6.11"
+    core-js: "npm:^3.8.2"
+    global: "npm:^4.4.0"
+    lodash: "npm:^4.17.21"
+    qs: "npm:^6.10.0"
+    regenerator-runtime: "npm:^0.13.7"
+    synchronous-promise: "npm:^2.0.15"
+    ts-dedent: "npm:^2.0.0"
+    unfetch: "npm:^4.2.0"
+    util-deprecate: "npm:^1.0.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 774a3f3acc7ec38045d508cf01b78877ffc973741a4b13fe55a2bbd7379edd65a6ebd14751ea59ba6224fd6242d433fe5a8234a07905cf67380d8e9889ba31da
+  languageName: node
+  linkType: hard
+
+"@storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0":
+  version: 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0
+  resolution: "@storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    endent: "npm:^2.0.1"
+    find-cache-dir: "npm:^3.3.1"
+    flat-cache: "npm:^3.0.4"
+    micromatch: "npm:^4.0.2"
+    react-docgen-typescript: "npm:^2.1.1"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    typescript: ">= 3.x"
+    webpack: ">= 4"
+  checksum: 0e3f369d5ac9ee2b466f8df75db8824bedca9a86f12b6265ec13f12416d8002d1f7aae4c04ffe019276a68dd6704b2c96df5398fb95951ec422b311139517f18
+  languageName: node
+  linkType: hard
+
+"@storybook/react@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/react@npm:6.5.9"
+  dependencies:
+    "@babel/preset-flow": "npm:^7.12.1"
+    "@babel/preset-react": "npm:^7.12.10"
+    "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.3"
+    "@storybook/addons": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/core": "npm:6.5.9"
+    "@storybook/core-common": "npm:6.5.9"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/docs-tools": "npm:6.5.9"
+    "@storybook/node-logger": "npm:6.5.9"
+    "@storybook/react-docgen-typescript-plugin": "npm:1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0"
+    "@storybook/semver": "npm:^7.3.2"
+    "@storybook/store": "npm:6.5.9"
+    "@types/estree": "npm:^0.0.51"
+    "@types/node": "npm:^14.14.20 || ^16.0.0"
+    "@types/webpack-env": "npm:^1.16.0"
+    acorn: "npm:^7.4.1"
+    acorn-jsx: "npm:^5.3.1"
+    acorn-walk: "npm:^7.2.0"
+    babel-plugin-add-react-displayname: "npm:^0.0.5"
+    babel-plugin-react-docgen: "npm:^4.2.1"
+    core-js: "npm:^3.8.2"
+    escodegen: "npm:^2.0.0"
+    fs-extra: "npm:^9.0.1"
+    global: "npm:^4.4.0"
+    html-tags: "npm:^3.1.0"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-element-to-jsx-string: "npm:^14.3.4"
+    react-refresh: "npm:^0.11.0"
+    read-pkg-up: "npm:^7.0.1"
+    regenerator-runtime: "npm:^0.13.7"
+    ts-dedent: "npm:^2.0.0"
+    util-deprecate: "npm:^1.0.2"
+    webpack: "npm:>=4.43.0 <6.0.0"
+  peerDependencies:
+    "@babel/core": ^7.11.5
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    require-from-string: ^2.0.2
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@storybook/builder-webpack4":
+      optional: true
+    "@storybook/builder-webpack5":
+      optional: true
+    "@storybook/manager-webpack4":
+      optional: true
+    "@storybook/manager-webpack5":
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    build-storybook: bin/build.js
+    start-storybook: bin/index.js
+    storybook-server: bin/index.js
+  checksum: 8d13f0ee121fe55ea0218c70211a8fb020e61a2b0a209727be2dccfa583e647047dfe14780b2632585925997ff47e1ee1a21329767c10764a202e541b9a3e927
+  languageName: node
+  linkType: hard
+
+"@storybook/router@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/router@npm:6.5.9"
+  dependencies:
+    "@storybook/client-logger": "npm:6.5.9"
+    core-js: "npm:^3.8.2"
+    memoizerific: "npm:^1.11.3"
+    qs: "npm:^6.10.0"
+    regenerator-runtime: "npm:^0.13.7"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: fde4514ea42005f2ecfac6cf252951c1ff2d5fdbfd2a61e92605f23ec824e86e32adbbea32c24c5062a36696a7a33bb854fe7d2f096773296bc9bd2ccde111cc
+  languageName: node
+  linkType: hard
+
+"@storybook/semver@npm:^7.3.2":
+  version: 7.3.2
+  resolution: "@storybook/semver@npm:7.3.2"
+  dependencies:
+    core-js: "npm:^3.6.5"
+    find-up: "npm:^4.1.0"
+  bin:
+    semver: bin/semver.js
+  checksum: 2888467b4d1ee4a931dc6e3cea4659f72d2f86292e3510a1c6b626c6b56d199e22b297f8875ebe075aa637c77778534ae27c5395dc17a9ecc3622620e82ba538
+  languageName: node
+  linkType: hard
+
+"@storybook/store@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/store@npm:6.5.9"
+  dependencies:
+    "@storybook/addons": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    core-js: "npm:^3.8.2"
+    fast-deep-equal: "npm:^3.1.3"
+    global: "npm:^4.4.0"
+    lodash: "npm:^4.17.21"
+    memoizerific: "npm:^1.11.3"
+    regenerator-runtime: "npm:^0.13.7"
+    slash: "npm:^3.0.0"
+    stable: "npm:^0.1.8"
+    synchronous-promise: "npm:^2.0.15"
+    ts-dedent: "npm:^2.0.0"
+    util-deprecate: "npm:^1.0.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 8a72281fd5ce487720d496f0e3c423ee6f8035e06a9e5684d4dac89a29b2a80012546f7a714e0f99f1fc84a2cd88f4b6669267b78a3843bbe216fe9c30c33325
+  languageName: node
+  linkType: hard
+
+"@storybook/telemetry@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/telemetry@npm:6.5.9"
+  dependencies:
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/core-common": "npm:6.5.9"
+    chalk: "npm:^4.1.0"
+    core-js: "npm:^3.8.2"
+    detect-package-manager: "npm:^2.0.1"
+    fetch-retry: "npm:^5.0.2"
+    fs-extra: "npm:^9.0.1"
+    global: "npm:^4.4.0"
+    isomorphic-unfetch: "npm:^3.1.0"
+    nanoid: "npm:^3.3.1"
+    read-pkg-up: "npm:^7.0.1"
+    regenerator-runtime: "npm:^0.13.7"
+  checksum: 3b24fab8989a8fc11db5e56cb8bb0925363e88090d41d7666a0e4324c74c88aa9cde89b2c6ee40c3d5c91b02b860b00d2c8e083b8d7cd31b31561a640227e738
+  languageName: node
+  linkType: hard
+
+"@storybook/theming@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/theming@npm:6.5.9"
+  dependencies:
+    "@storybook/client-logger": "npm:6.5.9"
+    core-js: "npm:^3.8.2"
+    memoizerific: "npm:^1.11.3"
+    regenerator-runtime: "npm:^0.13.7"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: e0cecbd012b8c6494bb6d9645bef3a755116671dbcd8fe38f5d92bcfa90f6b8f9388562b22ea3d1e5f063ba409617408c9e5fb28a47277fbc56bea11a36467bf
+  languageName: node
+  linkType: hard
+
+"@storybook/ui@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/ui@npm:6.5.9"
+  dependencies:
+    "@storybook/addons": "npm:6.5.9"
+    "@storybook/api": "npm:6.5.9"
+    "@storybook/channels": "npm:6.5.9"
+    "@storybook/client-logger": "npm:6.5.9"
+    "@storybook/components": "npm:6.5.9"
+    "@storybook/core-events": "npm:6.5.9"
+    "@storybook/router": "npm:6.5.9"
+    "@storybook/semver": "npm:^7.3.2"
+    "@storybook/theming": "npm:6.5.9"
+    core-js: "npm:^3.8.2"
+    memoizerific: "npm:^1.11.3"
+    qs: "npm:^6.10.0"
+    regenerator-runtime: "npm:^0.13.7"
+    resolve-from: "npm:^5.0.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 77672cdf9471c6e7b512bd67d418d7e801db6191fa253e68d3161dcecd95c0e16ee16e09602d58a58205daae370d62bec3c7d8767dcdcf6d242015e6cd9068aa
+  languageName: node
+  linkType: hard
+
 "@stroncium/procfs@npm:^1.2.1":
   version: 1.2.1
   resolution: "@stroncium/procfs@npm:1.2.1"
   checksum: 2aba601993e86d4e5a2d1c2919f3ce890dad951fd277432c1697709e489e9ecf941f07179a6f50d2f8161fc037ae3ba483a3985b6e226dccc75cb6e49bb63209
-  languageName: node
-  linkType: hard
-
-"@svgr/babel-plugin-add-jsx-attribute@npm:^5.4.0":
-  version: 5.4.0
-  resolution: "@svgr/babel-plugin-add-jsx-attribute@npm:5.4.0"
-  checksum: b24f5dd890fbd18ee6476fcc775eae681bff43d0cd90621b559f96e040bd7be1dc21232892e9ee093af1ef05cd7a8a2c92d5cfabf672e7eea5c45ab309344c16
-  languageName: node
-  linkType: hard
-
-"@svgr/babel-plugin-remove-jsx-attribute@npm:^5.4.0":
-  version: 5.4.0
-  resolution: "@svgr/babel-plugin-remove-jsx-attribute@npm:5.4.0"
-  checksum: 7481f53c21b8cf3b9c196e463893253d84bff3681aaa09ebc9305323e69ef60c295c03df5053673ff00bad3856d8dcda46f8f37b02e0731cbea43bbfcfe31caa
-  languageName: node
-  linkType: hard
-
-"@svgr/babel-plugin-remove-jsx-empty-expression@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@svgr/babel-plugin-remove-jsx-empty-expression@npm:5.0.1"
-  checksum: f4eefc07f47ff547b872c4893138b0ca462f38ba3d78c218f139ab9db139ea1fa5938cc4ef632998d94bd60f385457d14dea4fef1e99bbe10c13c483ecd77426
-  languageName: node
-  linkType: hard
-
-"@svgr/babel-plugin-replace-jsx-attribute-value@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@svgr/babel-plugin-replace-jsx-attribute-value@npm:5.0.1"
-  checksum: 6d73fbae60c3d9f347c02065e6a98364aae2037ac9c5495dca7039db3087abd103ceb43b16b11ccccc129cd01e500c5fc5daaa10f2aada42f913401e0cfce085
-  languageName: node
-  linkType: hard
-
-"@svgr/babel-plugin-svg-dynamic-title@npm:^5.4.0":
-  version: 5.4.0
-  resolution: "@svgr/babel-plugin-svg-dynamic-title@npm:5.4.0"
-  checksum: a2bb14c33e70a30e6a4df7c508cb321f94a4cd686eecd7e8f6b05e1f2c84d4fd2d3fb181a8ff192fa61e01949e20aafc853c19e4d8526a75ffc0df1ca111d4f8
-  languageName: node
-  linkType: hard
-
-"@svgr/babel-plugin-svg-em-dimensions@npm:^5.4.0":
-  version: 5.4.0
-  resolution: "@svgr/babel-plugin-svg-em-dimensions@npm:5.4.0"
-  checksum: 5ddd7ac4747544999b55fcb2a3afc9ae7874b5b871a2bf7992eab9600b79911e972f20afc659ca0e91031d8195ca6c703461a8916338e4ba1fac93c58225f8d0
-  languageName: node
-  linkType: hard
-
-"@svgr/babel-plugin-transform-react-native-svg@npm:^5.4.0":
-  version: 5.4.0
-  resolution: "@svgr/babel-plugin-transform-react-native-svg@npm:5.4.0"
-  checksum: 2dc92d30785ebd1d68411c28361a940d820fc4fcf8d39bfa9dba2b99a7d9385658c21099c49d8bdd2317e5a1393152bc00e6435889e54318638d5df81e02cd25
-  languageName: node
-  linkType: hard
-
-"@svgr/babel-plugin-transform-svg-component@npm:^5.5.0":
-  version: 5.5.0
-  resolution: "@svgr/babel-plugin-transform-svg-component@npm:5.5.0"
-  checksum: ddf7c083b496fab6eb54055270f282089991321e881e52936ccd8786ad412b4d8a8e7dac69f334395f5dba3481532a48a05a00bfd4d3525aa830938ccf6f313c
-  languageName: node
-  linkType: hard
-
-"@svgr/babel-preset@npm:^5.5.0":
-  version: 5.5.0
-  resolution: "@svgr/babel-preset@npm:5.5.0"
-  dependencies:
-    "@svgr/babel-plugin-add-jsx-attribute": "npm:^5.4.0"
-    "@svgr/babel-plugin-remove-jsx-attribute": "npm:^5.4.0"
-    "@svgr/babel-plugin-remove-jsx-empty-expression": "npm:^5.0.1"
-    "@svgr/babel-plugin-replace-jsx-attribute-value": "npm:^5.0.1"
-    "@svgr/babel-plugin-svg-dynamic-title": "npm:^5.4.0"
-    "@svgr/babel-plugin-svg-em-dimensions": "npm:^5.4.0"
-    "@svgr/babel-plugin-transform-react-native-svg": "npm:^5.4.0"
-    "@svgr/babel-plugin-transform-svg-component": "npm:^5.5.0"
-  checksum: 61a66897533a7f17845133d895fe47a8f18b5d0bd6649f5217e0a574d334b786c85b80fe79798735af5ca1e5965d0cc7a8144d28f9cf9591e8d15b87a13c3b4d
-  languageName: node
-  linkType: hard
-
-"@svgr/core@npm:^5.5.0":
-  version: 5.5.0
-  resolution: "@svgr/core@npm:5.5.0"
-  dependencies:
-    "@svgr/plugin-jsx": "npm:^5.5.0"
-    camelcase: "npm:^6.2.0"
-    cosmiconfig: "npm:^7.0.0"
-  checksum: 7499e271842b68b1db89513d1241c9dc4fc006c10c01ef54841a1c27254e478749e3ec311adfab5e7eab28fb7e71c1cd79c0ada88b32463b239a98d7f1c3169a
-  languageName: node
-  linkType: hard
-
-"@svgr/hast-util-to-babel-ast@npm:^5.5.0":
-  version: 5.5.0
-  resolution: "@svgr/hast-util-to-babel-ast@npm:5.5.0"
-  dependencies:
-    "@babel/types": "npm:^7.12.6"
-  checksum: 77e3fc20c5454844b1942c44cb40189eccc613f37cc9dde2f9d4ed91feb41d35bc382847ad5bf9a56cf47ab8683501822478a2b6123b9e05d8096fb745cd6fca
-  languageName: node
-  linkType: hard
-
-"@svgr/plugin-jsx@npm:^5.5.0":
-  version: 5.5.0
-  resolution: "@svgr/plugin-jsx@npm:5.5.0"
-  dependencies:
-    "@babel/core": "npm:^7.12.3"
-    "@svgr/babel-preset": "npm:^5.5.0"
-    "@svgr/hast-util-to-babel-ast": "npm:^5.5.0"
-    svg-parser: "npm:^2.0.2"
-  checksum: 776a57dba3d4deef0270e4162a9e70467520c39026840a2330f67f1a1981e98bb21e79e637c9098532a680c63fc1a608daef837ac2c00e0ef5e60bd612b14183
   languageName: node
   linkType: hard
 
@@ -1359,13 +3494,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/braces@npm:*":
-  version: 3.0.1
-  resolution: "@types/braces@npm:3.0.1"
-  checksum: c0d610f2474b174dc87946b57a8a7ecf5a14a49ef4217fc1134bcd32bcbd8a07eeaee5ea88b861effeee554cf28dc62867008e39049a574a2162985a40586333
-  languageName: node
-  linkType: hard
-
 "@types/chai-subset@npm:^1.3.3":
   version: 1.3.3
   resolution: "@types/chai-subset@npm:1.3.3"
@@ -1382,7 +3510,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:8.4.5":
+"@types/eslint-scope@npm:^3.7.3":
+  version: 3.7.4
+  resolution: "@types/eslint-scope@npm:3.7.4"
+  dependencies:
+    "@types/eslint": "npm:*"
+    "@types/estree": "npm:*"
+  checksum: c0a026bc2bca7e1e41018a6e95abd32e165c2c515739ac9e96fd45ccf5d0fff93c96556edc243d5d23f4cca0c9c752572b72df425555a2af8d6b043fa5e104f2
+  languageName: node
+  linkType: hard
+
+"@types/eslint@npm:*, @types/eslint@npm:8.4.5":
   version: 8.4.5
   resolution: "@types/eslint@npm:8.4.5"
   dependencies:
@@ -1406,6 +3544,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/estree@npm:^0.0.51":
+  version: 0.0.51
+  resolution: "@types/estree@npm:0.0.51"
+  checksum: a5fbdddce8a2b79477d0cb92d9998e42d5ae096d98ed0245983551423fd849c0e34a9877a2bb503dbd6716265d03f520155c2047996460872f82f25e1811e0c7
+  languageName: node
+  linkType: hard
+
+"@types/glob@npm:*, @types/glob@npm:^7.1.1":
+  version: 7.2.0
+  resolution: "@types/glob@npm:7.2.0"
+  dependencies:
+    "@types/minimatch": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 28f927f9e0d7f5cecafc843e0c97f79fd3afe5874d71f35ad9343352fe14fd4d6e4136cc07688e46680d1972561751fdf4468762c7de5ac32f8cf902cd1f230f
+  languageName: node
+  linkType: hard
+
+"@types/hast@npm:^2.0.0":
+  version: 2.3.4
+  resolution: "@types/hast@npm:2.3.4"
+  dependencies:
+    "@types/unist": "npm:*"
+  checksum: 863ce633c5ba5b5dcaa4361fb53b8d381d62f100b24760843c6c1fafc23d86364012ee76d8c9d5386fefcf69fed6832db087df1a3107e49c235135cf83e0602c
+  languageName: node
+  linkType: hard
+
+"@types/hoist-non-react-statics@npm:*":
+  version: 3.3.1
+  resolution: "@types/hoist-non-react-statics@npm:3.3.1"
+  dependencies:
+    "@types/react": "npm:*"
+    hoist-non-react-statics: "npm:^3.3.0"
+  checksum: 6e252131d90ced0948b559b187bac10185040dbb0e2dcfb5c40d065003ea94c79d483e82b5961100e2e021057be3b1087fbbe34d55a302ca7aba6d059470fb33
+  languageName: node
+  linkType: hard
+
+"@types/html-minifier-terser@npm:^5.0.0":
+  version: 5.1.2
+  resolution: "@types/html-minifier-terser@npm:5.1.2"
+  checksum: 69bb911e0736b7f7e7a78643d002772efc3e5b51458d4ea17fdd04f7d9560241d17e33f7e604aa06858a4d2b8544e705b46d77edc64f29884ecc7c052006a02d
+  languageName: node
+  linkType: hard
+
 "@types/is-ci@npm:3.0.0":
   version: 3.0.0
   resolution: "@types/is-ci@npm:3.0.0"
@@ -1415,10 +3596,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.9":
+"@types/is-function@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@types/is-function@npm:1.0.1"
+  checksum: 26e6f0c27a0bcff5e24fabc274f685496d2c6ddd3a7662c6495a17fafb2287d3632ce6f2497428eced57c2d916b14346f7e3c5327cde36322a6552378a7178a2
+  languageName: node
+  linkType: hard
+
+"@types/istanbul-lib-coverage@npm:^2.0.1":
+  version: 2.0.4
+  resolution: "@types/istanbul-lib-coverage@npm:2.0.4"
+  checksum: c866b0c4f8d6f7167a5f65900d4ab792cdeae4df98f13c6b26f69d8abf31d4ef599d1b6938164ac1d0d1c7cdfcc3ca7174ac0176c788c2a019ee2fa815cf1e01
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
   checksum: 8e5c6dd393411418e3d803ab0a09862b4ed47f73e7ed990f3b907dd41cc4d2f2b4f7aed9a39c7fd2acaa80314ac1397a5e2e5e6c25a338f01bbfba708cc70d8e
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:^4.14.167":
+  version: 4.14.182
+  resolution: "@types/lodash@npm:4.14.182"
+  checksum: 8224b6d4cf7ee471024875c7acae1f19fa7221d28bc1008d79d67503d0707a395f95a6996ee77863f1ffeee15709da0709241b6c3e27d7e498927399f53e7298
   languageName: node
   linkType: hard
 
@@ -1431,12 +3633,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/micromatch@npm:4.0.2":
-  version: 4.0.2
-  resolution: "@types/micromatch@npm:4.0.2"
-  dependencies:
-    "@types/braces": "npm:*"
-  checksum: ac7ec28d57ac61a85bd2859c69d096192e8ef66cc9d3c5fcb4531eeec3b090b1ff1be132e65eff6a16be14b9a30083cf488a402c094890c654db861aafee4669
+"@types/minimatch@npm:*":
+  version: 3.0.5
+  resolution: "@types/minimatch@npm:3.0.5"
+  checksum: 1e3ad77c3a101452cb52919d33e5f47f13b4fe66a6566409e1b555b975831cf127fb9ee347d6d9d1648784dac816dc955f8766991de9c3de80a80cc15890c5f1
   languageName: node
   linkType: hard
 
@@ -1454,7 +3654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-fetch@npm:^2.6.2":
+"@types/node-fetch@npm:^2.5.7, @types/node-fetch@npm:^2.6.2":
   version: 2.6.2
   resolution: "@types/node-fetch@npm:2.6.2"
   dependencies:
@@ -1474,9 +3674,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>=12":
-  version: 18.6.1
-  resolution: "@types/node@npm:18.6.1"
-  checksum: 3433d312e77e34f1dd58573d83d1479b7983ea73e8a71d1e0612717c31137283bb412240137ccc816af45bed2674cd735861c88b06513f683636a8110d1949b1
+  version: 18.6.2
+  resolution: "@types/node@npm:18.6.2"
+  checksum: a853c5c9d28cf9064fff053b8cbb20b0d646f5ef7bc004226c9189f490bc3c0d16f6a3cada2ad16e67e40eca82c8f60d33b8b271b6852d9db9779f67596100d2
   languageName: node
   linkType: hard
 
@@ -1487,10 +3687,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^14.0.10 || ^16.0.0, @types/node@npm:^14.14.20 || ^16.0.0":
+  version: 16.11.46
+  resolution: "@types/node@npm:16.11.46"
+  checksum: 1eda2f400383f9170db57a9bcbb22823800626b94cd1d44562955284b200e31ab98cdcbaa8086f6f8a4943c75852d12f54e5b3a6148ee3074eafbb689e236694
+  languageName: node
+  linkType: hard
+
 "@types/normalize-package-data@npm:^2.4.0":
   version: 2.4.1
   resolution: "@types/normalize-package-data@npm:2.4.1"
   checksum: 4b597289520e45e54f408e91712f31fe7818e2c5d977eefecfae9db1f921a80247470d4f77da2dc8e1ef85bf0b5852ad64faf0106d88647421e45350d124f74f
+  languageName: node
+  linkType: hard
+
+"@types/npmlog@npm:^4.1.2":
+  version: 4.1.4
+  resolution: "@types/npmlog@npm:4.1.4"
+  checksum: a8d3dc83d0ba6b7bb8e9e451c4f96c266137a5c27377d3c683d8fc3e2d6a80996ecced479473b3638bffbb562c90d0ea0b1be82e77c3e048195449632e1d1d58
   languageName: node
   linkType: hard
 
@@ -1501,10 +3715,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/parse5@npm:^5.0.0":
+  version: 5.0.3
+  resolution: "@types/parse5@npm:5.0.3"
+  checksum: edd64878d92434a3335ebf87771d52ac89f784d5d5956f7ef30d1a3def763382c8efb8431e09c84e283060db0a5e41a9aff424bf80206183b0e80f409898d8cf
+  languageName: node
+  linkType: hard
+
 "@types/prettier@npm:2.6.3":
   version: 2.6.3
   resolution: "@types/prettier@npm:2.6.3"
   checksum: 8a25ff9ebd6e2d2614cc351894c332b01d306ddb7363e0b1fa56ae5ff5b5639ae58905e213608dff311ef987d6834f532c92964860272e4fc3e95b4824d76e58
+  languageName: node
+  linkType: hard
+
+"@types/pretty-hrtime@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@types/pretty-hrtime@npm:1.0.1"
+  checksum: c0d0a5c05931251488693024e75034859c2b4bc0d6a333c1b3901dd7798b797a2ec9b25afe45d27cbae821e36c2a58bc7c9c1bbb1ab881d29bb0cc784f884459
   languageName: node
   linkType: hard
 
@@ -1515,7 +3743,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:18.0.15":
+"@types/qs@npm:^6.9.5":
+  version: 6.9.7
+  resolution: "@types/qs@npm:6.9.7"
+  checksum: 6ad8b468d122ef64878bef150efb428532cc8768ec66fac61b9abb1ff0f30520d86138290e753d5f179e6fd01ba3a51c56e2e0a7a6e40b5d1cfd8b701f70367d
+  languageName: node
+  linkType: hard
+
+"@types/react-syntax-highlighter@npm:11.0.5":
+  version: 11.0.5
+  resolution: "@types/react-syntax-highlighter@npm:11.0.5"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: edc905da819dd0073a908adf78c5e2b3f8fba61e5e73d7d08f381527b60380db96d59a709bc7877ef70eecf0c719f5db73eba90d49c9e0dbefcea134d27d8c7a
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:*, @types/react@npm:18.0.15":
   version: 18.0.15
   resolution: "@types/react@npm:18.0.15"
   dependencies:
@@ -1542,6 +3786,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/source-list-map@npm:*":
+  version: 0.1.2
+  resolution: "@types/source-list-map@npm:0.1.2"
+  checksum: e966d2fc8b845ac0f2d9898087e5313801ef6cdf7be6e7c906b78652c1b75f4b5b83a7ab1c30587c18327ebec50fad04700d81e763ac0e3dd674173d40e429d7
+  languageName: node
+  linkType: hard
+
 "@types/strip-bom@npm:^3.0.0":
   version: 3.0.0
   resolution: "@types/strip-bom@npm:3.0.0"
@@ -1556,10 +3807,69 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/unist@npm:*, @types/unist@npm:^2.0.2":
+"@types/styled-components@npm:5.1.25":
+  version: 5.1.25
+  resolution: "@types/styled-components@npm:5.1.25"
+  dependencies:
+    "@types/hoist-non-react-statics": "npm:*"
+    "@types/react": "npm:*"
+    csstype: "npm:^3.0.2"
+  checksum: 96b09fe31259320265bcb5fb0264a1d9193ae2266ee4612f65233989f344ecca88e71295062cb08492855691723f2c50f4368bd210c774d32483d089cb95bbef
+  languageName: node
+  linkType: hard
+
+"@types/tapable@npm:^1, @types/tapable@npm:^1.0.5":
+  version: 1.0.8
+  resolution: "@types/tapable@npm:1.0.8"
+  checksum: fee4703164b230e22bedb876ed77b4208bf3fe7878fe01d2aecd9d5bc51ca2c0887cb264af734b736de4b4d1e848f1f5d1eaa56b5722d8ee7625a5f9a78e3b1f
+  languageName: node
+  linkType: hard
+
+"@types/uglify-js@npm:*":
+  version: 3.16.0
+  resolution: "@types/uglify-js@npm:3.16.0"
+  dependencies:
+    source-map: "npm:^0.6.1"
+  checksum: 5e24922fd68071b69515f1d602922dad0c0b55d194b253bbc9df37405e1fef22d73c681dc33b0f4901d789c41a8810535e8e7c1281ca079279eab816dd339647
+  languageName: node
+  linkType: hard
+
+"@types/unist@npm:*, @types/unist@npm:^2.0.0, @types/unist@npm:^2.0.2, @types/unist@npm:^2.0.3":
   version: 2.0.6
   resolution: "@types/unist@npm:2.0.6"
   checksum: 4731b678e9d9ab41386b48bf67a5da9000705c6ae84cd4fc866f774004f5e8190a33117dbff95efc54b44404deaa08a421b646823b01c57db3eeb0652cdc71a9
+  languageName: node
+  linkType: hard
+
+"@types/webpack-env@npm:^1.16.0":
+  version: 1.17.0
+  resolution: "@types/webpack-env@npm:1.17.0"
+  checksum: 60eec3ffd179c299e11661b8b90c7fe3a931f9055bded232c82465b66645441e91be58d17d658a8ad41e00a5c20dffc6fff29529ad21dc3b83da36a426aaa816
+  languageName: node
+  linkType: hard
+
+"@types/webpack-sources@npm:*":
+  version: 3.2.0
+  resolution: "@types/webpack-sources@npm:3.2.0"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/source-list-map": "npm:*"
+    source-map: "npm:^0.7.3"
+  checksum: 7ab51f331c35901b9fec579e6065a4d989ba5a4b16b667f0642900a338070479e59e9664c31886a46b22712200d5ecbb494b6a8ffbdf8508b35e71da3ce51b3f
+  languageName: node
+  linkType: hard
+
+"@types/webpack@npm:^4.41.26, @types/webpack@npm:^4.41.8":
+  version: 4.41.32
+  resolution: "@types/webpack@npm:4.41.32"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/tapable": "npm:^1"
+    "@types/uglify-js": "npm:*"
+    "@types/webpack-sources": "npm:*"
+    anymatch: "npm:^3.0.0"
+    source-map: "npm:^0.6.0"
+  checksum: f507ba834868a0ff7e282cb4fcfa7409b2777445fbcc0af65bb048c282a7b49fd35d1020328cc8879f69e7194f43ed8be9317d62ceb0a84700a3f83e582482fe
   languageName: node
   linkType: hard
 
@@ -1698,6 +4008,352 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/ast@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/ast@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/helper-numbers": "npm:1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
+  checksum: 159a27ef59e21bcdf09ff5c79d115d5c24fe27ed08bc15e3c20884031e8820cce3e3c83ec4ba87a9834d422cffcfa3cb4506541ea9cfcd86394d9a8a7a9771b4
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/ast@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/ast@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/helper-module-context": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/wast-parser": "npm:1.9.0"
+  checksum: 9f962c3c0bd706e4ec1af7b6eca8157b0546001cbc6f0ad0ff2966c5319bd3cecf35bc0d44e28309745b9f0fe7367a28ffc8a1a357dd61a047b00795f526c581
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/floating-point-hex-parser@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.11.1"
+  checksum: aa15ad9f7681f813b5e09041d000fd8285e458a90e0881ad3d26e746a7588889c19de27b1e09a3beba2d643c5bdaf698a8161dba2b56188c09bdfdd9f28abf6d
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/floating-point-hex-parser@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.9.0"
+  checksum: 3709af9669249b7772d49bc2568d75a6765034a514c59e57c7e81e01468d5c8e0bfc52626e97dda6f8cc6847fc84558725c88d5a7a90a9607a37f5d3274bb5a2
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-api-error@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-api-error@npm:1.11.1"
+  checksum: 4ce8d9f8bec21c9a797a84c7219e590854dc01cc72f3c51a8defd7baa4ff93fc799ec686f30475b425136e8dc8c937428142209b006fd62bef8ac35370108549
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-api-error@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-api-error@npm:1.9.0"
+  checksum: e1f5cc8ff4efa16cf82bdef277f9a9f5d99c3a103db2c5e040c3bf216e49929ace06143b9f0ab47fb7b7ba0d7263e1e125cbab5f1c8399130699d81a7baa3fe3
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-buffer@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-buffer@npm:1.11.1"
+  checksum: 7119688f189d2715cb14ccc1d6203be6721d8d280bbbf8d5198ab5b49e89f6a16d0cfc675bb8385fe73b20d0da2a52fbc4cc27608074fb68a7762ab9f990469d
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-buffer@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-buffer@npm:1.9.0"
+  checksum: 6bbcc9dd4a06a8860c104d3f91b4874cdf5ebea2b16301a06ce4c9866c6f8794cfdb99567b8f361e3ca82ac5f20db8b8d0ebafde5d4d1b365b4269e53c2bc60c
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-code-frame@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-code-frame@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/wast-printer": "npm:1.9.0"
+  checksum: 0a333ec514d9fca5648202d48b97bdcdcb6ac5f32c79238b80d2bfeb373367d635b96aa9eafd6eef64ee49d3ad342ddc1daa9b6eaf420a2a29e0c65d947eb985
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-fsm@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-fsm@npm:1.9.0"
+  checksum: c1f27b2481a4c8f356156b8ea65fe0b1e9a9589d407008082766bac81cebc8d2552c3c15da710d3297dc0702c5be31135d9fb380639d759b8cb1f9e8219f4c3d
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-module-context@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-module-context@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.9.0"
+  checksum: 676ffa735df55969bf086e03d492de61bec96523d0b786b607d7887ca6d8d49cbc18568245de3706d1e3d7ee893c15767ad1432c15ac590eedb21d1e0a7eaa4a
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-numbers@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-numbers@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser": "npm:1.11.1"
+    "@webassemblyjs/helper-api-error": "npm:1.11.1"
+    "@xtuc/long": "npm:4.2.2"
+  checksum: effd79c29be006c3abc8f4f501f56da1408cb86bae4aaffe2562902ffee28c794e49dac64ba306079f624a011fdab0c7e0c26bd5d873cabd237df7d7e26a240c
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-wasm-bytecode@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.11.1"
+  checksum: ce787ae26e2202205d6d3a85e5dc1c4b7fc3b0cdddf0bf0b371655e223c2962fa3299f8b1922c27ee405f99ee5c7b798824f0b8c1609321db0482e7f78c77281
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-wasm-bytecode@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.9.0"
+  checksum: d05985487c79ee4e2fda67e3df2794764190ff8c3922b9e681bc0704511d1e46c27d1aba12a23d99714293e8d6bb11465528389b3135a773d3a6ea261549e9c8
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-wasm-section@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-wasm-section@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.11.1"
+    "@webassemblyjs/helper-buffer": "npm:1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
+    "@webassemblyjs/wasm-gen": "npm:1.11.1"
+  checksum: 03b25f62ca3d0f9ef5d17fe55c2c6798f38f759adee04eece0447e586e11343dd7e2da777a505023a00ec98bd08a9ac4d2aaf35f704e1c50f9503db010084cc5
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-wasm-section@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-wasm-section@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-buffer": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/wasm-gen": "npm:1.9.0"
+  checksum: 7e58577177ed2aa70e83c252e68c97b59e7584d73f398ae01c587f5b159d8cf7deb535d46b1af1232afbcf5c2a52c319479c44db071fec5cd102042bec2c4603
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/ieee754@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/ieee754@npm:1.11.1"
+  dependencies:
+    "@xtuc/ieee754": "npm:^1.2.0"
+  checksum: 71fd7b8691d2bc06d3b58ba7085b8c343ee063eb6aa750f715c70fcd42dc0776a67693897419906cf5748cb252d14c6ee882d7cabbfc21470539d3967e3a03af
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/ieee754@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/ieee754@npm:1.9.0"
+  dependencies:
+    "@xtuc/ieee754": "npm:^1.2.0"
+  checksum: 6960b198fea65cd470724c48348ff032f6dc3b366c6536905032010efd1d3b8999b84cd813b4af050833d7aeeabb1bcc0c1a2dcc6c70a7083967c0d2d703c6f5
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/leb128@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/leb128@npm:1.11.1"
+  dependencies:
+    "@xtuc/long": "npm:4.2.2"
+  checksum: 5815c1e725b4f58b12c55f7b5493279c42f1cd4bc730e59feb63d6ad7a8f70d2494e17c269b6251ba254d67bd093fb6bc1fc6da7778b41e7c6f3816295525cb5
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/leb128@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/leb128@npm:1.9.0"
+  dependencies:
+    "@xtuc/long": "npm:4.2.2"
+  checksum: 59771ea0df566f17578862b33e6793e969d9a2f57f96c9e5bf3acfbe5fa5c72c6040bb16743df4719bc8647a8bc1fedd4997f6a36acd94ee8095e187ea860e6d
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/utf8@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/utf8@npm:1.11.1"
+  checksum: 388e3951becdaac209a3b4d7b95527c97b688bdd8f2265a2d54a856d0807c0361d57ffbd8f01466698e2467d1f5239c3058218a22c9b1062a3abd917ec6e382e
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/utf8@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/utf8@npm:1.9.0"
+  checksum: 934826e116f30a634f2f69b5fb5a029d2c26959155d8624bfdca4535e9c8113cef4095d56a6f95029d25aba5b99ac51d71a7fae096b23fd48d5dc10882ce2f61
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-edit@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-edit@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.11.1"
+    "@webassemblyjs/helper-buffer": "npm:1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
+    "@webassemblyjs/helper-wasm-section": "npm:1.11.1"
+    "@webassemblyjs/wasm-gen": "npm:1.11.1"
+    "@webassemblyjs/wasm-opt": "npm:1.11.1"
+    "@webassemblyjs/wasm-parser": "npm:1.11.1"
+    "@webassemblyjs/wast-printer": "npm:1.11.1"
+  checksum: 0954fd4123683ae713544cdf558fc2a1e86cc2965e9bef0ad8132c3fd16c275e030662e58867b829a3349b3bb1988ae2867ea1fb154113c52b7a73fdf5f5f5a9
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-edit@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wasm-edit@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-buffer": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-section": "npm:1.9.0"
+    "@webassemblyjs/wasm-gen": "npm:1.9.0"
+    "@webassemblyjs/wasm-opt": "npm:1.9.0"
+    "@webassemblyjs/wasm-parser": "npm:1.9.0"
+    "@webassemblyjs/wast-printer": "npm:1.9.0"
+  checksum: e7f8e0a4f9fe6ee3c5cbbb2e370232bef5b32db5e2735bd8fcdaa52227458e71e32e325d9f990da40d62947f74c6cf1d4f43afdfff406818ef019f08f8d407b6
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-gen@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-gen@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
+    "@webassemblyjs/ieee754": "npm:1.11.1"
+    "@webassemblyjs/leb128": "npm:1.11.1"
+    "@webassemblyjs/utf8": "npm:1.11.1"
+  checksum: 7f155afbac250e391fe846104df12159411315c9b6464ccc397806a47612fcd76366ea5f48663ff8ee47a4c04eeccf9d12710504d950d5e7ef8623d48074d578
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-gen@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wasm-gen@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/ieee754": "npm:1.9.0"
+    "@webassemblyjs/leb128": "npm:1.9.0"
+    "@webassemblyjs/utf8": "npm:1.9.0"
+  checksum: cd8e22a608510417e15b83692f829739c307da5929dbf86291829a289aff5dabd0ff131e644327ac7ce09cf1a5301cf4fbc69633aeea8837c9bf2b5695d0d577
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-opt@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-opt@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.11.1"
+    "@webassemblyjs/helper-buffer": "npm:1.11.1"
+    "@webassemblyjs/wasm-gen": "npm:1.11.1"
+    "@webassemblyjs/wasm-parser": "npm:1.11.1"
+  checksum: 9d86f58d254f3ccf5674dfb69a6476c8a46734306d8b452c46539afec069980b847449581b79966c9e8a6ee734b4757c25456ed84d154f82e50cad2ae25c5f75
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-opt@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wasm-opt@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-buffer": "npm:1.9.0"
+    "@webassemblyjs/wasm-gen": "npm:1.9.0"
+    "@webassemblyjs/wasm-parser": "npm:1.9.0"
+  checksum: 6a0647a538d171dc1166c9e7a66fb46bc7f781cbf6145957acd584c3df0c2b6f5c0aa108cbf3c3b69edc0bb4c08659e3c0158a76ae2b35fcc4da740fe361448e
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-parser@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-parser@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.11.1"
+    "@webassemblyjs/helper-api-error": "npm:1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
+    "@webassemblyjs/ieee754": "npm:1.11.1"
+    "@webassemblyjs/leb128": "npm:1.11.1"
+    "@webassemblyjs/utf8": "npm:1.11.1"
+  checksum: c851c47e8393ad0f34c0376a699bede172b6edf775b67817cafbca5839f5bf48a1f6dfad3c99b96a1d77c17c714138a074462714cddb730e6d30b440d5fedb8b
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-parser@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wasm-parser@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-api-error": "npm:1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.9.0"
+    "@webassemblyjs/ieee754": "npm:1.9.0"
+    "@webassemblyjs/leb128": "npm:1.9.0"
+    "@webassemblyjs/utf8": "npm:1.9.0"
+  checksum: 41d8d9a370c6cb3f0595d794caed1a29e2569815c70659ac040f631a5053c51df61db626dfd424671996981a76c4bff7a1d1b79c837cc48bbae5d48bb6f32504
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wast-parser@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wast-parser@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/floating-point-hex-parser": "npm:1.9.0"
+    "@webassemblyjs/helper-api-error": "npm:1.9.0"
+    "@webassemblyjs/helper-code-frame": "npm:1.9.0"
+    "@webassemblyjs/helper-fsm": "npm:1.9.0"
+    "@xtuc/long": "npm:4.2.2"
+  checksum: fcd4c5255fd57edf82629408338f4dd90bccfd8953cc7a506eba998db172e4df481fe1e2a0fb1c285f0b6d8ba54ba86d7e2e993559014888f02bba3c9fefd98d
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wast-printer@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wast-printer@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.11.1"
+    "@xtuc/long": "npm:4.2.2"
+  checksum: c662c7f2d482ecf5c6c96addf40c8c691fd6d207a01ba4a0465429699d848c5efd34915f65cc37d2d86d63962ae2ca2e35c44d4adbb67f8cf8f80952f94e6fbe
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wast-printer@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wast-printer@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/wast-parser": "npm:1.9.0"
+    "@xtuc/long": "npm:4.2.2"
+  checksum: f203ef6742dc38fa9c9d967fa5230f34f2096abdd3f8d0abeabaddea654fc245475e1dad4fa12f7f9415189fdc8db7269d52d2182bf563b56ab860a3f02dfdf3
+  languageName: node
+  linkType: hard
+
+"@xtuc/ieee754@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@xtuc/ieee754@npm:1.2.0"
+  checksum: 9e8984d890576772a1f6f05e513da380672e70688f08e53c7bd3b65d0373078933771ca81b6b025a86bd742352d91b6da5a329bf7b45560aff3588d811a7e403
+  languageName: node
+  linkType: hard
+
+"@xtuc/long@npm:4.2.2":
+  version: 4.2.2
+  resolution: "@xtuc/long@npm:4.2.2"
+  checksum: 48078981fd16688328aeedc04b1ae3a016ee5ee2a81dff709bf7313a0e8b21494e39b959f8e800e00ba361d74e9a9ce3be365ee369e079c23c8e257f103f8604
+  languageName: node
+  linkType: hard
+
 "JSONStream@npm:^1.0.4":
   version: 1.3.5
   resolution: "JSONStream@npm:1.3.5"
@@ -1717,12 +4373,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-jsx@npm:^5.3.2":
+"accepts@npm:~1.3.5, accepts@npm:~1.3.8":
+  version: 1.3.8
+  resolution: "accepts@npm:1.3.8"
+  dependencies:
+    mime-types: "npm:~2.1.34"
+    negotiator: "npm:0.6.3"
+  checksum: 4634cf08b9ccf6a7618a006d54b6a29c159c233eb40194e397373308244ebad0436155d0604463d401673d47c1e1f65ea1237d58cbe8ad780d01f20f61ce19f4
+  languageName: node
+  linkType: hard
+
+"acorn-import-assertions@npm:^1.7.6":
+  version: 1.8.0
+  resolution: "acorn-import-assertions@npm:1.8.0"
+  peerDependencies:
+    acorn: ^8
+  checksum: 7963bf636b8ee03e93507beea867317bcbb09c53050aaebc86b49022478dda7ea3110ea0ffab1957db016d83f57e92c307c54adef113812bb19445a4e4a1aa98
+  languageName: node
+  linkType: hard
+
+"acorn-jsx@npm:^5.3.1, acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
   peerDependencies:
     acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
   checksum: 868f313daf8fcab419af9bbde57a739f127bf926856c7d3f2eb7d0d5153a0658331bfe3fd4d185687447538ef4154317e003ca25a9cf5cb4eb69c956740caee8
+  languageName: node
+  linkType: hard
+
+"acorn-walk@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "acorn-walk@npm:7.2.0"
+  checksum: eeb1b1caa68a6505a2c61710f2cc85a89c9d208dd25de2cc6d0a2142968d630760359336ced43f28a0bcb516af217fb997c1e74fc78fc23083b17ef8110b502d
   languageName: node
   linkType: hard
 
@@ -1733,12 +4415,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn@npm:^6.4.1":
+  version: 6.4.2
+  resolution: "acorn@npm:6.4.2"
+  bin:
+    acorn: bin/acorn
+  checksum: 386210368ad25d01b1fa4bd2d6c6184ab33de4a59b854c62ac0d654241389ea4510c47f0da6e1af93f30aec69631225aa396b5e5d423046a7d06fd54dfd7df66
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^7.4.1":
+  version: 7.4.1
+  resolution: "acorn@npm:7.4.1"
+  bin:
+    acorn: bin/acorn
+  checksum: a7cebd1811f1dd177a6e684184f2608ded8a1783f126c8b2f794d70275e1a1e02c64fdd77eb84298d9754a295d507769033385b049d04f033b424110a02656ef
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.1":
   version: 8.8.0
   resolution: "acorn@npm:8.8.0"
   bin:
     acorn: bin/acorn
   checksum: 15b10fb381a8a0394a718eba147e120b9d1ae6ed087e61612ee5fda94f98182e5fcd78ef6725c027dc3c5677ce920617c14c359d7777e8ef6a058d2ba113f81f
+  languageName: node
+  linkType: hard
+
+"address@npm:^1.0.1":
+  version: 1.2.0
+  resolution: "address@npm:1.2.0"
+  checksum: c6fcdd4eb9cfbc2998713788cc1d20a211d93d038cbb1a28d90fb4f76530c8baa3402037f56ce6c70c89be65f9b8789c1b0e7dcbaf5fedafdff4f2f1fca0297c
   languageName: node
   linkType: hard
 
@@ -1782,7 +4489,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.0, ajv@npm:^6.12.4":
+"airbnb-js-shims@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "airbnb-js-shims@npm:2.2.1"
+  dependencies:
+    array-includes: "npm:^3.0.3"
+    array.prototype.flat: "npm:^1.2.1"
+    array.prototype.flatmap: "npm:^1.2.1"
+    es5-shim: "npm:^4.5.13"
+    es6-shim: "npm:^0.35.5"
+    function.prototype.name: "npm:^1.1.0"
+    globalthis: "npm:^1.0.0"
+    object.entries: "npm:^1.1.0"
+    object.fromentries: "npm:^2.0.0 || ^1.0.0"
+    object.getownpropertydescriptors: "npm:^2.0.3"
+    object.values: "npm:^1.1.0"
+    promise.allsettled: "npm:^1.0.0"
+    promise.prototype.finally: "npm:^3.1.0"
+    string.prototype.matchall: "npm:^4.0.0 || ^3.0.1"
+    string.prototype.padend: "npm:^3.0.0"
+    string.prototype.padstart: "npm:^3.0.0"
+    symbol.prototype.description: "npm:^1.0.0"
+  checksum: 3fbd19077429d6946da5f2ac9db066f918fc0b670d59e631009b9795c16cc4f17d3c0f7577530ad2ef858117edd0f0e8848c136083a944cbb3f5e2a22c32bd28
+  languageName: node
+  linkType: hard
+
+"ajv-errors@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "ajv-errors@npm:1.0.1"
+  peerDependencies:
+    ajv: ">=5.0.0"
+  checksum: df6e4d1c82967d953018d09d4f3c6cce9cd41709214034d07607d293409311d80ca541a73089b0d1277f484114f1f1b96aa69814875d7a548de66e67b02d6ee3
+  languageName: node
+  linkType: hard
+
+"ajv-keywords@npm:^3.1.0, ajv-keywords@npm:^3.4.1, ajv-keywords@npm:^3.5.2":
+  version: 3.5.2
+  resolution: "ajv-keywords@npm:3.5.2"
+  peerDependencies:
+    ajv: ^6.9.1
+  checksum: e1c951fc981a115aab493cc08b756c94a89b4a1b98af848d42a6cc706bef73fea763f9958ee51cd31e6f2f34c1d7158157e40ebd8cd38347385fe448419a57e7
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^6.1.0, ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.12.2, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -1806,10 +4556,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-align@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "ansi-align@npm:3.0.1"
+  dependencies:
+    string-width: "npm:^4.1.0"
+  checksum: 399240ac035be1af1fa20de12c5ad3b50c7d2e404c352ac58917916aaa827f1cdd00a4e8154fabcc485b8cee43596e42829862bc83560481f7db2bfe38c3110d
+  languageName: node
+  linkType: hard
+
 "ansi-colors@npm:4.1.3":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
   checksum: a185f33883845ae5e37481749adad1cf1abf86c41c3ad3ad4c5b951f911ecb4df6a802da9acd4329726fbed0a29a43ae5ae38d179b453bc33f59bfbbb69a5c38
+  languageName: node
+  linkType: hard
+
+"ansi-colors@npm:^3.0.0":
+  version: 3.2.4
+  resolution: "ansi-colors@npm:3.2.4"
+  checksum: 9d628a6daf10aaaf4c4426b8b6cf7170022a0b5321bc3542084e5e2b3cb12df8fc3c055a1aee81a5f30f429f43c5bb18e9d8ba5168413a97fa53b41ea25c317f
   languageName: node
   linkType: hard
 
@@ -1819,6 +4585,22 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.21.3"
   checksum: da33f33b3b792e7273cefc1ec150afbc332cab602757d2ab70fb90e5c5cfa173b10bc4a0d9d0c60479ed60e25cdf35897a82f1e498987358a6087b99300872cc
+  languageName: node
+  linkType: hard
+
+"ansi-html-community@npm:0.0.8, ansi-html-community@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "ansi-html-community@npm:0.0.8"
+  bin:
+    ansi-html: bin/ansi-html
+  checksum: 56bf91b53357d6fa66973feb7294140fdc9da5a11fa63f354ef05ae3b47db4bb367ca1a6960f09c572d395b05ed16c698ce5f23d172eae9c6e4b50213aff8deb
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "ansi-regex@npm:2.1.1"
+  checksum: 2e99d1e01bb3bb0318b41c595acf106287c23693016753484928b33483cbdced97674ae006b0207a89bbf475c2a8ccbf1f007abfa26defdcebd166d63390c69b
   languageName: node
   linkType: hard
 
@@ -1868,6 +4650,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-to-html@npm:^0.6.11":
+  version: 0.6.15
+  resolution: "ansi-to-html@npm:0.6.15"
+  dependencies:
+    entities: "npm:^2.0.0"
+  bin:
+    ansi-to-html: bin/ansi-to-html
+  checksum: e1664b47ace47f1071426e3fb125ba4d4e582214cb4d0430fda6c08c2facc44d09c7b6c6532115e5ac9879ac7e6d6e1ab1bc47a210bb474a679c0f4312a87e86
+  languageName: node
+  linkType: hard
+
+"anymatch@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "anymatch@npm:2.0.0"
+  dependencies:
+    micromatch: "npm:^3.1.4"
+    normalize-path: "npm:^2.1.1"
+  checksum: 204a66bee0be646fd01665a05e64a24a85817386b9476fe95768aa00c0c201ffdee291651b9d29bbe0dda14898f4418fad0581ca44378c4a44dfe019defded81
+  languageName: node
+  linkType: hard
+
+"anymatch@npm:^3.0.0, anymatch@npm:~3.1.2":
+  version: 3.1.2
+  resolution: "anymatch@npm:3.1.2"
+  dependencies:
+    normalize-path: "npm:^3.0.0"
+    picomatch: "npm:^2.0.4"
+  checksum: b9266228a3e1406086ece57c20f9cbfc9755375218697c79a71fba9245ad23a672687314422e97753fbb3bccd245d7c76974d7c15ba513386b499de6ba002300
+  languageName: node
+  linkType: hard
+
+"app-root-dir@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "app-root-dir@npm:1.0.2"
+  checksum: dfbd8f2dcdf75354d1f1fcb5ae4b30b5d1f60f7bff53c2e1819066f679a17af5db674a4591f070b41825d42c08da5daf004601b352b538025485727e47c403a7
+  languageName: node
+  linkType: hard
+
 "aproba@npm:^1.0.3 || ^2.0.0":
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
@@ -1875,13 +4695,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"are-we-there-yet@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "are-we-there-yet@npm:3.0.0"
+"aproba@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "aproba@npm:1.2.0"
+  checksum: 57bbff1b287201cb850e405ee5a494ba1e9e0d4064c21a454d7643863b3f2228d654c4e463841aef9273d7398b9b779d86e2239f11381a1bb5aa7055d03f3d3d
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "are-we-there-yet@npm:2.0.0"
   dependencies:
     delegates: "npm:^1.0.0"
     readable-stream: "npm:^3.6.0"
-  checksum: 01eab104abc13225a6c59efcd4e307f5b7e7b6991c1741c50cc4f30da172b3b4374e3b8cf4641f3bd4152d2c66a14aaaf384aa953b0634bb625d81318f9de1c7
+  checksum: 8e178f4924d1062cf04df1afb27927f005429805027ea5f8d751cb66287910a3584b9f0548d0a7aa490dff60a0600e1f31da0bb53344f65f0836234529908d3a
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "are-we-there-yet@npm:3.0.1"
+  dependencies:
+    delegates: "npm:^1.0.0"
+    readable-stream: "npm:^3.6.0"
+  checksum: 7137e25713c611cf38054434ba377e2f7ad3a4bbdb7ac3565ed5caac786080d1c86ed0b280edd917b4c1001ee0d6ed7bdd53effd69b5af4251e5a4fd18d09fbe
   languageName: node
   linkType: hard
 
@@ -1899,6 +4736,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arr-diff@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "arr-diff@npm:4.0.0"
+  checksum: 78a8179b5a19e555e3628d8f846a587e25efb091c0ef0f3327040e1b1e6f50b1f052f24895afb500a9fd41540d8fcc839389a703e3617c60b10fd90b32bd172b
+  languageName: node
+  linkType: hard
+
+"arr-flatten@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "arr-flatten@npm:1.1.0"
+  checksum: e14e0b554eb39e8a5534db0a35cc2c43032d057b3206a35ce28ecbd30e10b910515ba196eaa7858d7c678fbe23aae09f72b1098f44dde23b3891c15455169421
+  languageName: node
+  linkType: hard
+
+"arr-union@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "arr-union@npm:3.1.0"
+  checksum: 33bb361cdf82f358cae449fee5cce600e05a683a2d929a13df32c709a1181121a9235280b19a3e4bf43228a3af6c82377eba91eba0123ebee3eb5d5468d2d522
+  languageName: node
+  linkType: hard
+
+"array-find-index@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "array-find-index@npm:1.0.2"
+  checksum: 8b39efbf2ccac370a402ebfce086a9a541e749903379940b4ee01f9c8d1f41e1a144b8ca6b9a645b8c1ab61259df96acc14eab15c5959006381fdd862cb7c33b
+  languageName: node
+  linkType: hard
+
+"array-flatten@npm:1.1.1":
+  version: 1.1.1
+  resolution: "array-flatten@npm:1.1.1"
+  checksum: 4f31d5671990976098f6ea9d82986748f43d0d44e3ab815d84d33cd5369ee964386804213619d4d050b33fe1cefa5e1420e98d350cd0162ab087d9d58c02d1c4
+  languageName: node
+  linkType: hard
+
 "array-ify@npm:^1.0.0":
   version: 1.0.0
   resolution: "array-ify@npm:1.0.0"
@@ -1906,7 +4778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.5":
+"array-includes@npm:^3.0.3, array-includes@npm:^3.1.5":
   version: 3.1.5
   resolution: "array-includes@npm:3.1.5"
   dependencies:
@@ -1926,7 +4798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-union@npm:^1.0.1":
+"array-union@npm:^1.0.1, array-union@npm:^1.0.2":
   version: 1.0.2
   resolution: "array-union@npm:1.0.2"
   dependencies:
@@ -1949,7 +4821,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flatmap@npm:^1.3.0":
+"array-unique@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "array-unique@npm:0.3.2"
+  checksum: 1f74f496ca981b2756b5eb3edb85e39d881635fa838784616de3d7e7b3cfa660e492b44f75f7f805cdafdae1d9a14c0c12dfde889a74c4de56a428a929f0f797
+  languageName: node
+  linkType: hard
+
+"array.prototype.flat@npm:^1.2.1":
+  version: 1.3.0
+  resolution: "array.prototype.flat@npm:1.3.0"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.2"
+    es-shim-unscopables: "npm:^1.0.0"
+  checksum: 879a2e557d39d01896d13058da43ad1a1acd85b1d97ae0e60affd00896c18f830fb8d9bd137ae3f4bd8e6b5c829f503fa7dd7ee2b415fdecdc28c91bede0ed79
+  languageName: node
+  linkType: hard
+
+"array.prototype.flatmap@npm:^1.2.1, array.prototype.flatmap@npm:^1.3.0":
   version: 1.3.0
   resolution: "array.prototype.flatmap@npm:1.3.0"
   dependencies:
@@ -1961,6 +4852,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array.prototype.map@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "array.prototype.map@npm:1.0.4"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.0"
+    es-array-method-boxes-properly: "npm:^1.0.0"
+    is-string: "npm:^1.0.7"
+  checksum: 04b883bc7e40d502dd6c5ac858cc784c9bc7e4d0e5aa82734adbe376290db69ee2ed59f93ab2bff8239a921e4424bdff9c7b24ba70de27929ad2e30ed0b7682d
+  languageName: node
+  linkType: hard
+
+"array.prototype.reduce@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "array.prototype.reduce@npm:1.0.4"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.2"
+    es-array-method-boxes-properly: "npm:^1.0.0"
+    is-string: "npm:^1.0.7"
+  checksum: 621180d401ec2a38d38292eb9dbaf913b03b04970929bb9a412e779e653dd7360ab18fff9271635ef3240c38fec3f7f7124c1405ea616d85555dc91ffce7b159
+  languageName: node
+  linkType: hard
+
 "arrify@npm:^1.0.1":
   version: 1.0.1
   resolution: "arrify@npm:1.0.1"
@@ -1968,10 +4885,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assert-never@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "assert-never@npm:1.2.1"
-  checksum: 8a292c9fdec1a10cd8673f21d41e4cd478c7266ba2c6648c442d49bbce06123d90889ad99d9794185ac0c319fbbc8e5369d45f0033c136b53c7b0c12c3ba9045
+"arrify@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "arrify@npm:2.0.1"
+  checksum: 29cf671ec2787421dde2aaca2e908812f9305089a8ee7fc725ff6e20cfa03d79ddf358377b0c7e297a2cf443194b784d4faf4ad6474023c2c4c87dc728948cc3
+  languageName: node
+  linkType: hard
+
+"asn1.js@npm:^5.2.0":
+  version: 5.4.1
+  resolution: "asn1.js@npm:5.4.1"
+  dependencies:
+    bn.js: "npm:^4.0.0"
+    inherits: "npm:^2.0.1"
+    minimalistic-assert: "npm:^1.0.0"
+    safer-buffer: "npm:^2.1.0"
+  checksum: 5c36f81388e344c9417866bd20acd2d4164d2bc2827d4fd0e35714f8701a249b9c6118c70720758fe710a4723d65699c5be1e827f89e9eff1dbd1bfe910300fd
+  languageName: node
+  linkType: hard
+
+"assert@npm:^1.1.1":
+  version: 1.5.0
+  resolution: "assert@npm:1.5.0"
+  dependencies:
+    object-assign: "npm:^4.1.1"
+    util: "npm:0.10.3"
+  checksum: ebe0f1b40f7d68ed96b74610cd68fb4cffa04174a49e1828a9a465f3e572a3f367b10ee318b600faeac5120274a76531dbf6d2045860dd604c0f91311c4d1b29
   languageName: node
   linkType: hard
 
@@ -1982,10 +4921,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assign-symbols@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "assign-symbols@npm:1.0.0"
+  checksum: 312d61d37abf72e003e4946683f1e824bd722d0101e6efe5fea016827634dca5f4e92b84f077886a3acd33c435d2f8fca6fbd29d6b08199615df66f919351fcc
+  languageName: node
+  linkType: hard
+
+"ast-types@npm:^0.14.2":
+  version: 0.14.2
+  resolution: "ast-types@npm:0.14.2"
+  dependencies:
+    tslib: "npm:^2.0.1"
+  checksum: edbf4486d9714dd13a4e56dd5ed38315653964da38e8241537879180aabf03cc232996cd704d6de99e0f3dd03f3ec33f976d23bee6b1f3bbc615a798dbb97871
+  languageName: node
+  linkType: hard
+
 "astral-regex@npm:^2.0.0":
   version: 2.0.0
   resolution: "astral-regex@npm:2.0.0"
   checksum: e24f6eb6f33ba55ffe8d89c60ab490791cd29772a896339388db11efcbfcd6da0d6ed59b655933f7c26ca4c2ae926f86d21bdedb142b69829d9d4a1074faa1d2
+  languageName: node
+  linkType: hard
+
+"async-each@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "async-each@npm:1.0.3"
+  checksum: a33c8c479af6cf7090a2138638411994bbcba762da1148a75c92d359d47d3a9264966e115ba7970fc1117a5e4a6618ae2d2f600054834886e8bb29007f0a46f1
   languageName: node
   linkType: hard
 
@@ -1996,10 +4958,335 @@ __metadata:
   languageName: node
   linkType: hard
 
+"at-least-node@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "at-least-node@npm:1.0.0"
+  checksum: fed1be4307a3752f3a863a6e0219c58fe6838ee95c77ecafffd2a72bbfe4ff33695777e4bffe2a095ef5671c638b803a55e0d39a728c7b0afa9adaa5900444bd
+  languageName: node
+  linkType: hard
+
+"atob@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "atob@npm:2.1.2"
+  bin:
+    atob: bin/atob.js
+  checksum: af5b2c7d2b7beb2ece862c42999ef7e43ed1ecf67857f44b021ea4267fdf7aad4b8ec5f59fde2a2d581b6cbda9108e979274642e2c6ab3b32a4203ee1ddad3d2
+  languageName: node
+  linkType: hard
+
+"autoprefixer@npm:^9.8.6":
+  version: 9.8.8
+  resolution: "autoprefixer@npm:9.8.8"
+  dependencies:
+    browserslist: "npm:^4.12.0"
+    caniuse-lite: "npm:^1.0.30001109"
+    normalize-range: "npm:^0.1.2"
+    num2fraction: "npm:^1.2.2"
+    picocolors: "npm:^0.2.1"
+    postcss: "npm:^7.0.32"
+    postcss-value-parser: "npm:^4.1.0"
+  bin:
+    autoprefixer: bin/autoprefixer
+  checksum: 41894a9c9e8fe27cfd96d8e6e3e06d7cc6c918663d019f531600bc329441cbe8e82f3ccaa9c8c602b31ee2dca7ebd89ad7054e8b88e5edb96356cfd622742c19
+  languageName: node
+  linkType: hard
+
+"babel-loader@npm:^8.0.0":
+  version: 8.2.5
+  resolution: "babel-loader@npm:8.2.5"
+  dependencies:
+    find-cache-dir: "npm:^3.3.1"
+    loader-utils: "npm:^2.0.0"
+    make-dir: "npm:^3.1.0"
+    schema-utils: "npm:^2.6.5"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+    webpack: ">=2"
+  checksum: 32dc3fafa9aec9f25dd6a19f314aa1cb5b60d331161ed2c7e552cbfba52831d39c4659c82a454095e6cc32ff3914b59f49049e56a7a8fdbfc502c5a926cd767a
+  languageName: node
+  linkType: hard
+
+"babel-plugin-add-react-displayname@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "babel-plugin-add-react-displayname@npm:0.0.5"
+  checksum: 886327cd2cabdf87a52a241dbea1e37b2b12e4616ef010add8e9c1ef8ce9675811265756bcd409145f14e0c768cfbd0a223b868ad739c3807753e207269a9e57
+  languageName: node
+  linkType: hard
+
+"babel-plugin-apply-mdx-type-prop@npm:1.6.22":
+  version: 1.6.22
+  resolution: "babel-plugin-apply-mdx-type-prop@npm:1.6.22"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:7.10.4"
+    "@mdx-js/util": "npm:1.6.22"
+  peerDependencies:
+    "@babel/core": ^7.11.6
+  checksum: 2859f350528593f0238fb8513339dda2455aa4acfa74ac4dd5a7d2bd5578e8b4d96a2dfbedd3de114e57a22a91d8fa834c19b22527db5e5135da0cc6c5cce936
+  languageName: node
+  linkType: hard
+
+"babel-plugin-dynamic-import-node@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "babel-plugin-dynamic-import-node@npm:2.3.3"
+  dependencies:
+    object.assign: "npm:^4.1.0"
+  checksum: 1c608f6dcf3cbb31222304bb8ae04ae0ed9b62f09692b29ab98f58cbc318305d9d2926467542b3f7efafb187a39c3fb4ea88562c2d5773d4fec5deb7825b0a36
+  languageName: node
+  linkType: hard
+
+"babel-plugin-extract-import-names@npm:1.6.22":
+  version: 1.6.22
+  resolution: "babel-plugin-extract-import-names@npm:1.6.22"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:7.10.4"
+  checksum: d2cfbc2ad9d795567c64ea3ab6a21b6f54d61df5dbea054abf18c9e2320c47068b29ae47a16163b778ecf64ba0afe66b8b58fa1315108fd431f723e74c80a634
+  languageName: node
+  linkType: hard
+
+"babel-plugin-macros@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "babel-plugin-macros@npm:3.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+    cosmiconfig: "npm:^7.0.0"
+    resolve: "npm:^1.19.0"
+  checksum: da60b82112080f124097bc2cb4250b14d2bce799adf007ad5f70f9d3539aaadca7f3b7b849c47397131b66db6b717b90e1687ef81a49b3be2a61e067dcbb434d
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-corejs2@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "babel-plugin-polyfill-corejs2@npm:0.3.2"
+  dependencies:
+    "@babel/compat-data": "npm:^7.17.7"
+    "@babel/helper-define-polyfill-provider": "npm:^0.3.2"
+    semver: "npm:^6.1.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 1faae7c9107ca2e851c063b5da13878669ab44b2c09a270f521f1de8d30dbef7cae2af2b98d2c70bf164d975efeadf848e28f6c1eed5dea9ec62228750754074
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-corejs3@npm:^0.1.0":
+  version: 0.1.7
+  resolution: "babel-plugin-polyfill-corejs3@npm:0.1.7"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": "npm:^0.1.5"
+    core-js-compat: "npm:^3.8.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 5a748bf71e922b5472d482e55fdf1b21dab77bac16c3bb194cfba3d81ed26c103faf746f92e340498ccb81a87dd6f0c2b76309476e509f75a84de2be927cae91
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-corejs3@npm:^0.5.2":
+  version: 0.5.3
+  resolution: "babel-plugin-polyfill-corejs3@npm:0.5.3"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": "npm:^0.3.2"
+    core-js-compat: "npm:^3.21.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3b65d6704eb3f81f374d5da1119e9c8d63b74310e44e8a314331ab8bf797a3e19ebf3e73f38ed8c19aa3e8f38b8e87b1adffe848f1c0e039a91dcf042ef6d65f
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-regenerator@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "babel-plugin-polyfill-regenerator@npm:0.3.1"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": "npm:^0.3.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 15dd96f60afc5799fc39c39ff45bbc7c984ed4737be44ef444fdd25b829c84cfed679cd5ff54526097091a6601a03c59d1f149a5533316e825efe53075ef4954
+  languageName: node
+  linkType: hard
+
+"babel-plugin-react-docgen@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "babel-plugin-react-docgen@npm:4.2.1"
+  dependencies:
+    ast-types: "npm:^0.14.2"
+    lodash: "npm:^4.17.15"
+    react-docgen: "npm:^5.0.0"
+  checksum: ebff1e4db5e0918ecd91713c46209aaf6fc116d03f74c01aee5156f0379c0db4ccc0214f06b50b8eb2c0c2bd263597be88d23973d662e616e1bae37451588f11
+  languageName: node
+  linkType: hard
+
+"babel-plugin-styled-components@npm:>= 1.12.0":
+  version: 2.0.7
+  resolution: "babel-plugin-styled-components@npm:2.0.7"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.16.0"
+    "@babel/helper-module-imports": "npm:^7.16.0"
+    babel-plugin-syntax-jsx: "npm:^6.18.0"
+    lodash: "npm:^4.17.11"
+    picomatch: "npm:^2.3.0"
+  peerDependencies:
+    styled-components: ">= 2"
+  checksum: d18be8e9050d64c83408d980b3e46a75ba406a85321567c9253ec2fc755b7d9ba6e04c2c3d555b68b7aeb8a947cf235e36904ad6aca08617332c0fd38bea2fff
+  languageName: node
+  linkType: hard
+
+"babel-plugin-syntax-jsx@npm:^6.18.0":
+  version: 6.18.0
+  resolution: "babel-plugin-syntax-jsx@npm:6.18.0"
+  checksum: dd37d9280c365776040a84b8191e3d39cb3e916d34e05af7065d5df921422cbf56a143dac97a5e2e98c08e7b979f453d126fe58433ac8fdec0e1dd79f47b4b08
+  languageName: node
+  linkType: hard
+
+"bail@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "bail@npm:1.0.5"
+  checksum: d765ff150b9cd46eb9d007c189e6e130b1b5b84fddfea919cbb1840d6fb06645ed2ef7c4204c77560b0d50050f8dbd3cc68d52d23ee061d851125c7a4c02e85d
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 9ca7fca1845f06edbd8478e209a2e8eed5bb148a021719e77affeaf0c61e45af20279e4540a9f11942acc27c078fc132ff0ebc9c16a403033cff5af3d8199f40
+  languageName: node
+  linkType: hard
+
+"base64-js@npm:^1.0.2":
+  version: 1.5.1
+  resolution: "base64-js@npm:1.5.1"
+  checksum: fbd7996978cfe0dd378103fa8999e4acee99b8840d49f452457fa8cb418bad4c20ec9ef6b196a0dc63591f0416a4b8c8d220607292cdaf3998b88685bc0f6c14
+  languageName: node
+  linkType: hard
+
+"base@npm:^0.11.1":
+  version: 0.11.2
+  resolution: "base@npm:0.11.2"
+  dependencies:
+    cache-base: "npm:^1.0.1"
+    class-utils: "npm:^0.3.5"
+    component-emitter: "npm:^1.2.1"
+    define-property: "npm:^1.0.0"
+    isobject: "npm:^3.0.1"
+    mixin-deep: "npm:^1.2.0"
+    pascalcase: "npm:^0.1.1"
+  checksum: f474b90436bf31d42a4d7cdb46f7bbe63d89173013003f9a4f7f60c8de5b7a3c0a824aeb46557925aa5b854f9d8367c9f8f443db5a57786f16bdee4259ab5f86
+  languageName: node
+  linkType: hard
+
+"better-opn@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "better-opn@npm:2.1.1"
+  dependencies:
+    open: "npm:^7.0.3"
+  checksum: d254a6d57df95695b698eba1f34de6e9c51f3905507636f87a43393c4277f41d15498dac5110107a81a7f64019b7a1f21c37ed07bf419990058ea8d4ad876b8d
+  languageName: node
+  linkType: hard
+
+"big-integer@npm:^1.6.7":
+  version: 1.6.51
+  resolution: "big-integer@npm:1.6.51"
+  checksum: fc20ceb6b15f635783e09b596749323850a39565b5c0a73831bd1f32270aa4103ef025e1ca7887333e9ba50625328f8c415e56f17131f6d6e737d2dcc4c4ee53
+  languageName: node
+  linkType: hard
+
+"big.js@npm:^5.2.2":
+  version: 5.2.2
+  resolution: "big.js@npm:5.2.2"
+  checksum: 1c63accd17ba7d86676380280190cf748c6f715b74ddc36a3999d20689f78e59f6f76958fb811d40b57efca8dfaaacdc4508521d06a8a8d1e86194bc0f4b4575
+  languageName: node
+  linkType: hard
+
+"binary-extensions@npm:^1.0.0":
+  version: 1.13.1
+  resolution: "binary-extensions@npm:1.13.1"
+  checksum: c3ea49b3f715cf5a19d2ed5f9d91b21bb254e453a77232e049a754cf15ee2710f910e5a93e2a32e2c1123ee3d8f15e263cc13cf59ac99b36275739522f26b004
+  languageName: node
+  linkType: hard
+
+"binary-extensions@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "binary-extensions@npm:2.2.0"
+  checksum: 16cf7c0cfd2d04c0d7a115473b14054d6b01c077d8894f5eadc53e0cc1a0bea512a6187b314b26c99efd0c5f02b2871ab413017916d9ecaa47fa23d0f519adc6
+  languageName: node
+  linkType: hard
+
+"bindings@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "bindings@npm:1.5.0"
+  dependencies:
+    file-uri-to-path: "npm:1.0.0"
+  checksum: 17581455207d7f731dfef93e18aebe1f4402e760a45e7fa02585ba6ccaf7bd0e91723d5587e01e222d5d890cd1c7958c69050b9d86d4256a5b7e4f108aebb669
+  languageName: node
+  linkType: hard
+
+"bluebird@npm:^3.5.5":
+  version: 3.7.2
+  resolution: "bluebird@npm:3.7.2"
+  checksum: 42df9603102ffbb71c0bc66056a66dce510ba136ab746fb2f783daa71843f14b6f22c2897cb224b556cc5546b9a524c224f6b1505e074310273a5ee5b222e072
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9":
+  version: 4.12.0
+  resolution: "bn.js@npm:4.12.0"
+  checksum: bfb4590775a29dad10c8d42da5ba7fca9d4f796f6d278cb27f53c6a6272df5e58a3ca58d879487c9584db9e7a8f73ac843117183bebea2d627c1f0db95848ec8
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^5.0.0, bn.js@npm:^5.1.1":
+  version: 5.2.1
+  resolution: "bn.js@npm:5.2.1"
+  checksum: 0c272b6eeda35a4d2a3bcf5f0cae54080eb876f5aa10789f67322ad891a27dc99f179b4362e1b5fc2e42c408fd8e0014afed4fdf30e4f346561302ea588fd095
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:1.20.0":
+  version: 1.20.0
+  resolution: "body-parser@npm:1.20.0"
+  dependencies:
+    bytes: "npm:3.1.2"
+    content-type: "npm:~1.0.4"
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    destroy: "npm:1.2.0"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.4.24"
+    on-finished: "npm:2.4.1"
+    qs: "npm:6.10.3"
+    raw-body: "npm:2.5.1"
+    type-is: "npm:~1.6.18"
+    unpipe: "npm:1.0.0"
+  checksum: 38cafb558592481cf3a65d1c25b1efe790283638d005bace09191e67e8495e4ae4e83dce761bef6164bde548eb64cdeccf8e81bbbad91af8c9d58a0256542ed4
+  languageName: node
+  linkType: hard
+
+"boolbase@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "boolbase@npm:1.0.0"
+  checksum: 87bbb5043cc4e0525f77e0103b833a3806875e7f402f70afbfefc1b08862ccea9c373b015706ca9f442b81a55acfaa5795dc0748d5548d00df81b01dc4555b69
+  languageName: node
+  linkType: hard
+
+"boxen@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "boxen@npm:5.1.2"
+  dependencies:
+    ansi-align: "npm:^3.0.0"
+    camelcase: "npm:^6.2.0"
+    chalk: "npm:^4.1.0"
+    cli-boxes: "npm:^2.2.1"
+    string-width: "npm:^4.2.2"
+    type-fest: "npm:^0.20.2"
+    widest-line: "npm:^3.1.0"
+    wrap-ansi: "npm:^7.0.0"
+  checksum: 5a9ca1befa07f7416f9aacf1ed65576c0e40c90885c6af878d9e6d73e944c7aeac3881f75af86a1af1cef4e7a0dd73c89d4021e969a31da123462fda49ba1f60
+  languageName: node
+  linkType: hard
+
+"bplist-parser@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "bplist-parser@npm:0.1.1"
+  dependencies:
+    big-integer: "npm:^1.6.7"
+  checksum: af4860a92af26b4d3aa9f3704faa3989eb14a106c9dafd30968f2a9c551fa202394dcdf79627ca71912c04101303ef5000b63f2b1f9dfbec051f2e30177621dc
   languageName: node
   linkType: hard
 
@@ -2022,7 +5309,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.2":
+"braces@npm:^2.3.1, braces@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "braces@npm:2.3.2"
+  dependencies:
+    arr-flatten: "npm:^1.1.0"
+    array-unique: "npm:^0.3.2"
+    extend-shallow: "npm:^2.0.1"
+    fill-range: "npm:^4.0.0"
+    isobject: "npm:^3.0.1"
+    repeat-element: "npm:^1.1.2"
+    snapdragon: "npm:^0.8.1"
+    snapdragon-node: "npm:^2.0.1"
+    split-string: "npm:^3.0.2"
+    to-regex: "npm:^3.0.1"
+  checksum: a50c475eebe6ef6b7f70c6fc59731b238662823357dc58d75bbded0dbbed39a2af88f777f91f421a27a9d3c4d9cd838586f46661a8a0e94a16efaa0b21cb2706
+  languageName: node
+  linkType: hard
+
+"braces@npm:^3.0.2, braces@npm:~3.0.2":
   version: 3.0.2
   resolution: "braces@npm:3.0.2"
   dependencies:
@@ -2031,17 +5336,122 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.20.2":
-  version: 4.21.2
-  resolution: "browserslist@npm:4.21.2"
+"brorand@npm:^1.0.1, brorand@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "brorand@npm:1.1.0"
+  checksum: f736e127fbac2d704b0b55935c297ec261112b93a178e15170da19c17500d448ebacff3b1edb075821363e8daecc739c062b40e920aa19b8cbed7f4fbe1ff6aa
+  languageName: node
+  linkType: hard
+
+"browserify-aes@npm:^1.0.0, browserify-aes@npm:^1.0.4":
+  version: 1.2.0
+  resolution: "browserify-aes@npm:1.2.0"
   dependencies:
-    caniuse-lite: "npm:^1.0.30001366"
-    electron-to-chromium: "npm:^1.4.188"
+    buffer-xor: "npm:^1.0.3"
+    cipher-base: "npm:^1.0.0"
+    create-hash: "npm:^1.1.0"
+    evp_bytestokey: "npm:^1.0.3"
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 20e57fc05ef1e4a1c7b1021a38d8497908a0bc59d224277bbb25af90de579bf15ef6cf9fb773af04dc67c9d5255df839a5029d79a30744c8bac0f7bc569de86e
+  languageName: node
+  linkType: hard
+
+"browserify-cipher@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "browserify-cipher@npm:1.0.1"
+  dependencies:
+    browserify-aes: "npm:^1.0.4"
+    browserify-des: "npm:^1.0.0"
+    evp_bytestokey: "npm:^1.0.0"
+  checksum: 6b18df4d19c85a24b4f5c603a7bd15ced0104fbaec70d59f5d4a96419769d0a8ed56d081e2b117a6615b27c170e3fa0b3489f684e8d8bd1e94ffabafeda57d28
+  languageName: node
+  linkType: hard
+
+"browserify-des@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "browserify-des@npm:1.0.2"
+  dependencies:
+    cipher-base: "npm:^1.0.1"
+    des.js: "npm:^1.0.0"
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.1.2"
+  checksum: 806b7373e09a5d862a0f7eeb589db4071f1636f9fca8857081acf5b87a3b39cdf3a064954a7b578be8b141a7d583364dbd0d3105dcb80f91495dff90e4cf5f76
+  languageName: node
+  linkType: hard
+
+"browserify-rsa@npm:^4.0.0, browserify-rsa@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "browserify-rsa@npm:4.1.0"
+  dependencies:
+    bn.js: "npm:^5.0.0"
+    randombytes: "npm:^2.0.1"
+  checksum: 26189fb42954a20c9f3d396d539736decc3400d179d773f701da4373057e8af03662e07f876d0211360c87b3cf3ee1e8996ca1f39e6c28c959a4faa23a60e40e
+  languageName: node
+  linkType: hard
+
+"browserify-sign@npm:^4.0.0":
+  version: 4.2.1
+  resolution: "browserify-sign@npm:4.2.1"
+  dependencies:
+    bn.js: "npm:^5.1.1"
+    browserify-rsa: "npm:^4.0.1"
+    create-hash: "npm:^1.2.0"
+    create-hmac: "npm:^1.1.7"
+    elliptic: "npm:^6.5.3"
+    inherits: "npm:^2.0.4"
+    parse-asn1: "npm:^5.1.5"
+    readable-stream: "npm:^3.6.0"
+    safe-buffer: "npm:^5.2.0"
+  checksum: 1d87600fda7cc67b65f73da21a1a92867d714f1e5629a35b7ae300b5c263f5a49a5d99ab1a6b525e22e238045917b24caaac0b342e53b6b162ca4fa558f60d12
+  languageName: node
+  linkType: hard
+
+"browserify-zlib@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "browserify-zlib@npm:0.2.0"
+  dependencies:
+    pako: "npm:~1.0.5"
+  checksum: c3b26a0e7e2734a29855912877f1602b3043794272b3e3f98e738b83d548232796edb6bec605e1a8895f83a338d5c5bd56d51e7135abd4e1271a5cc250ff18e5
+  languageName: node
+  linkType: hard
+
+"browserslist@npm:^4.12.0, browserslist@npm:^4.14.5, browserslist@npm:^4.20.2, browserslist@npm:^4.21.2":
+  version: 4.21.3
+  resolution: "browserslist@npm:4.21.3"
+  dependencies:
+    caniuse-lite: "npm:^1.0.30001370"
+    electron-to-chromium: "npm:^1.4.202"
     node-releases: "npm:^2.0.6"
-    update-browserslist-db: "npm:^1.0.4"
+    update-browserslist-db: "npm:^1.0.5"
   bin:
     browserslist: cli.js
-  checksum: 7d147a562c650f1f6ef54d44bc5b12da4a45a8ac4797424a2f8490066574ff42fbf7195f428c064a76c8426ce25e89ea572fbc0dc39e20a314480a1b57d98f8c
+  checksum: 1c12b4b9b69138e1697aee58ad8b7e706fc868a90c03f9973ad8cf2bc5b283ccda07b4e7e751b7301b6df4726a41c6e8a9245e18ab3b11e0e4bc2cbfaeabaff3
+  languageName: node
+  linkType: hard
+
+"buffer-from@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 2d8a264381325ee41959bb21bae76dc85b486f253e227a3fa70082c83f14c41665ce227ccda79e93ea2fc12e37a678fe956a6fa01b1876e6142eaf6554585ea4
+  languageName: node
+  linkType: hard
+
+"buffer-xor@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "buffer-xor@npm:1.0.3"
+  checksum: 057a5740571719edffcb209fbc5842150624b5a3d1ee427f569a85dc5785643e92870fe2506d7812b9125ce8be64e5a295450ae215a678657a738f06044a6adf
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^4.3.0":
+  version: 4.9.2
+  resolution: "buffer@npm:4.9.2"
+  dependencies:
+    base64-js: "npm:^1.0.2"
+    ieee754: "npm:^1.1.4"
+    isarray: "npm:^1.0.0"
+  checksum: baf84376f2cbef25d119e811a0f4188a8a03c2f0915d7062f3e32be1cb962a5b1bfc0bcc5f828b3203a2448b5b3beb96a40302e14133e741f476ebd59090b95e
   languageName: node
   linkType: hard
 
@@ -2049,6 +5459,98 @@ __metadata:
   version: 3.3.0
   resolution: "builtin-modules@npm:3.3.0"
   checksum: 69bd2a742dc2aa7e69fc39b3289123e642c693705b8532ceab120e66496ec7cc599e3bd1352c09b45571910fa923c101abe8e1e36e0bc652e4397b19e6efb0e6
+  languageName: node
+  linkType: hard
+
+"builtin-status-codes@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "builtin-status-codes@npm:3.0.0"
+  checksum: f3c8da6f02017a6af3f7ff67e91080862bb57c8b95584bb7eebe61c57a03fe9c66ba5ab08b030cce88bbfdc716b92f4ffce352d6a06ee44467195d6b0ecd30f2
+  languageName: node
+  linkType: hard
+
+"bytes@npm:3.0.0":
+  version: 3.0.0
+  resolution: "bytes@npm:3.0.0"
+  checksum: 40dcd3cf4c59b09b26fb5329bf4d84dfc01ca55ecd1190f6ed3e5b16c53e6ba1f5dda7e3df7b134fe5dbff2b67f91686e1a80e50e4f5d2246c0cab60ec75a4c2
+  languageName: node
+  linkType: hard
+
+"bytes@npm:3.1.2":
+  version: 3.1.2
+  resolution: "bytes@npm:3.1.2"
+  checksum: b9b056ed671c71c7e0f4ce7b60a0c17305d1e3e9b6c967e0e82ce85bd8fad16efa4df992177d429e253b47c45a716e6823a9d046b660b4b5b7e1e21b4801edfe
+  languageName: node
+  linkType: hard
+
+"c8@npm:7.12.0, c8@npm:^7.6.0":
+  version: 7.12.0
+  resolution: "c8@npm:7.12.0"
+  dependencies:
+    "@bcoe/v8-coverage": "npm:^0.2.3"
+    "@istanbuljs/schema": "npm:^0.1.3"
+    find-up: "npm:^5.0.0"
+    foreground-child: "npm:^2.0.0"
+    istanbul-lib-coverage: "npm:^3.2.0"
+    istanbul-lib-report: "npm:^3.0.0"
+    istanbul-reports: "npm:^3.1.4"
+    rimraf: "npm:^3.0.2"
+    test-exclude: "npm:^6.0.0"
+    v8-to-istanbul: "npm:^9.0.0"
+    yargs: "npm:^16.2.0"
+    yargs-parser: "npm:^20.2.9"
+  bin:
+    c8: bin/c8.js
+  checksum: b04042243eb30ec9d464e74565724340f95ba52007e34efcb30480b6bfea1ef6319806c1ed38c04a7917f224f8d74dac13a789fe7bc9cf835557201c215c3573
+  languageName: node
+  linkType: hard
+
+"cacache@npm:^12.0.2":
+  version: 12.0.4
+  resolution: "cacache@npm:12.0.4"
+  dependencies:
+    bluebird: "npm:^3.5.5"
+    chownr: "npm:^1.1.1"
+    figgy-pudding: "npm:^3.5.1"
+    glob: "npm:^7.1.4"
+    graceful-fs: "npm:^4.1.15"
+    infer-owner: "npm:^1.0.3"
+    lru-cache: "npm:^5.1.1"
+    mississippi: "npm:^3.0.0"
+    mkdirp: "npm:^0.5.1"
+    move-concurrently: "npm:^1.0.1"
+    promise-inflight: "npm:^1.0.1"
+    rimraf: "npm:^2.6.3"
+    ssri: "npm:^6.0.1"
+    unique-filename: "npm:^1.1.1"
+    y18n: "npm:^4.0.0"
+  checksum: 1e8fd7f77b1495f1fd78a32779583508e10e8b4814c993fc9466916e716683d084d924391deb5a9686f293105102472280174a5678ee9c5db7c551413060e600
+  languageName: node
+  linkType: hard
+
+"cacache@npm:^15.0.5":
+  version: 15.3.0
+  resolution: "cacache@npm:15.3.0"
+  dependencies:
+    "@npmcli/fs": "npm:^1.0.0"
+    "@npmcli/move-file": "npm:^1.0.1"
+    chownr: "npm:^2.0.0"
+    fs-minipass: "npm:^2.0.0"
+    glob: "npm:^7.1.4"
+    infer-owner: "npm:^1.0.4"
+    lru-cache: "npm:^6.0.0"
+    minipass: "npm:^3.1.1"
+    minipass-collect: "npm:^1.0.2"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.2"
+    mkdirp: "npm:^1.0.3"
+    p-map: "npm:^4.0.0"
+    promise-inflight: "npm:^1.0.1"
+    rimraf: "npm:^3.0.2"
+    ssri: "npm:^8.0.1"
+    tar: "npm:^6.0.2"
+    unique-filename: "npm:^1.1.1"
+  checksum: 7ee6c3ca9cddcb35071cfa592b54ef195b944b8df9dc844a2a4a5cb9a7dee1debb53b7bab4ec77b295d7310d59183829457c80bf55c56045bc3d8547c4e89d50
   languageName: node
   linkType: hard
 
@@ -2078,6 +5580,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cache-base@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "cache-base@npm:1.0.1"
+  dependencies:
+    collection-visit: "npm:^1.0.0"
+    component-emitter: "npm:^1.2.1"
+    get-value: "npm:^2.0.6"
+    has-value: "npm:^1.0.0"
+    isobject: "npm:^3.0.1"
+    set-value: "npm:^2.0.0"
+    to-object-path: "npm:^0.3.0"
+    union-value: "npm:^1.0.0"
+    unset-value: "npm:^1.0.0"
+  checksum: 0d763c37206a635d28d6c508d60595d08aaa1cfe2e193396fa23409b76275da64189d87e9bd4baec666a23e45401ee7902034936da8712e7999359472d3ce7ff
+  languageName: node
+  linkType: hard
+
 "call-bind@npm:^1.0.0, call-bind@npm:^1.0.2":
   version: 1.0.2
   resolution: "call-bind@npm:1.0.2"
@@ -2088,10 +5607,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"call-me-maybe@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "call-me-maybe@npm:1.0.1"
+  checksum: c8dc3d89d9e659b019bdcf03c737a4d258651673356cc3d5c8150177a6c3c46f112566774a1acab6e9e64440ac5a53f821dc057c7164a082760021ba82bf5ad3
+  languageName: node
+  linkType: hard
+
 "callsites@npm:^3.0.0, callsites@npm:^3.1.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: a0672a95746fb1be281d90ceedafb6584dd7c33e85bb9987d6caad53ac6eb313874fc2045230e8e08ef076e4aaa899342d99bd9c47bb1dd4f6a2740b62482ca2
+  languageName: node
+  linkType: hard
+
+"camel-case@npm:^4.1.1":
+  version: 4.1.2
+  resolution: "camel-case@npm:4.1.2"
+  dependencies:
+    pascal-case: "npm:^3.1.2"
+    tslib: "npm:^2.0.3"
+  checksum: 825dd52d9138ece5360a71384722a5f3438ba5df9008470e12b1692b04f4de69c09164fb92ea54bc5ef5716ed6fc14732e0f39d2aad8925c3ea28a71bd2ecc3a
+  languageName: node
+  linkType: hard
+
+"camelcase-css@npm:2.0.1":
+  version: 2.0.1
+  resolution: "camelcase-css@npm:2.0.1"
+  checksum: bd5de5ad8f378db59860e45a8d7a0a41b47a3cb76670a6f91a4056df957537b4c92819bacabcc284df8d11b3866e1496aadc4139792c7e3ee4a6f0615324ff14
+  languageName: node
+  linkType: hard
+
+"camelcase-keys@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "camelcase-keys@npm:2.1.0"
+  dependencies:
+    camelcase: "npm:^2.0.0"
+    map-obj: "npm:^1.0.0"
+  checksum: 7f84aa87faacee9e05c1aaac60891b2e991be8ceaf6b70145644961014f1121ee99bd15d75f81a9be87ebee25f7887dc214989373896e533fe42f4bb39b7fd54
   languageName: node
   linkType: hard
 
@@ -2118,6 +5671,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelcase@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "camelcase@npm:2.1.1"
+  checksum: e9685b796e250062a2630ffad8e6b9acbab424e324b23ed740782b58ce42b97b3f29ab5cc76f8bdfdb8803dab5f80558bfcfba6f51ce46941a7d99efc839f6c6
+  languageName: node
+  linkType: hard
+
 "camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
@@ -2132,10 +5692,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001366":
-  version: 1.0.30001370
-  resolution: "caniuse-lite@npm:1.0.30001370"
-  checksum: 8a8d8e9ab026aa8165da80e34a5f4814703314fef3197888ca30f6faca0af5c07532c16b45048d47fdfab9b9b110666c6ff541cc0e0dabf02b6b826a11d844c8
+"camelize@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "camelize@npm:1.0.0"
+  checksum: a13eb1b24d4b02909eb6f64525c1f924cad9ddbfcc0fee5b0d378e22b6aaf223eb98352c32cc53e6ee9fba28d469432d0aef7f0ecc01931d26aa811828568fd2
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001370":
+  version: 1.0.30001373
+  resolution: "caniuse-lite@npm:1.0.30001373"
+  checksum: a08c182c0afc9f34f252f3ff4919a5a95f697f39ff1c636745659b788460e46564bf975cf81b39914c2bf86247ae95bd994648a638ee7ced1daf186f63dc852a
+  languageName: node
+  linkType: hard
+
+"case-sensitive-paths-webpack-plugin@npm:^2.3.0":
+  version: 2.4.0
+  resolution: "case-sensitive-paths-webpack-plugin@npm:2.4.0"
+  checksum: 8885f0f2068d6bef1ae8d29ad36ce64ba2c2a48117b521b0f896948082621257b9b7299c22535343c1d39e884941ae9f31484473d32e1e73e23540c7dae8a23e
+  languageName: node
+  linkType: hard
+
+"ccount@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "ccount@npm:1.1.0"
+  checksum: 4fd7d159190dbf6c1dc1543762edc7c9564e945a46440ed26d99c56985848859c1f9ad86c89bdad06a1746f9f572604dbb6e21165c64b9358b6b20cdd5c3a84a
   languageName: node
   linkType: hard
 
@@ -2154,7 +5735,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.0.0":
+"chalk@npm:^2.0.0, chalk@npm:^2.4.1":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -2210,6 +5791,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:^2.1.8":
+  version: 2.1.8
+  resolution: "chokidar@npm:2.1.8"
+  dependencies:
+    anymatch: "npm:^2.0.0"
+    async-each: "npm:^1.0.1"
+    braces: "npm:^2.3.2"
+    fsevents: "npm:^1.2.7"
+    glob-parent: "npm:^3.1.0"
+    inherits: "npm:^2.0.3"
+    is-binary-path: "npm:^1.0.0"
+    is-glob: "npm:^4.0.0"
+    normalize-path: "npm:^3.0.0"
+    path-is-absolute: "npm:^1.0.0"
+    readdirp: "npm:^2.2.1"
+    upath: "npm:^1.1.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 5e67bc26ee8a81c409a36df7c4313230c4a6def71181b338b01a02f73b70ff4083838679ce4da515028f04cf36ec58b7cf30b927d34537edc5ca5ae33d9b3ea6
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.4.1, chokidar@npm:^3.4.2":
+  version: 3.5.3
+  resolution: "chokidar@npm:3.5.3"
+  dependencies:
+    anymatch: "npm:~3.1.2"
+    braces: "npm:~3.0.2"
+    fsevents: "npm:~2.3.2"
+    glob-parent: "npm:~5.1.2"
+    is-binary-path: "npm:~2.1.0"
+    is-glob: "npm:~4.0.1"
+    normalize-path: "npm:~3.0.0"
+    readdirp: "npm:~3.6.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: eb45bf6464f6c871e2b46926eaaf35abc06624d4ca8b894bc7c927d8ac808e680d977c37283276992159360767d51c64b4c9bb91ece91beceaf3cb4abe555f99
+  languageName: node
+  linkType: hard
+
+"chownr@npm:^1.1.1":
+  version: 1.1.4
+  resolution: "chownr@npm:1.1.4"
+  checksum: 011dfe9853fe7feed4fdcb25d2d3b2bf67957948f8e7988d7540aaf56e9cbfb5384d5b56808dfa140277be02401acdfa75f5b67b78576497e482ea8036666ed2
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^2.0.0":
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
@@ -2217,10 +5847,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chrome-trace-event@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "chrome-trace-event@npm:1.0.3"
+  checksum: c5ebf04331c4cd9112c9a4ae1d24dc0918fa9e4756de00dce7af149f9cf60b82cbe93573b6552e1099fd4c71a8a688c463f01222cdc48e47935f26a6fa86b989
+  languageName: node
+  linkType: hard
+
 "ci-info@npm:^3.1.0, ci-info@npm:^3.2.0, ci-info@npm:^3.3.2":
   version: 3.3.2
   resolution: "ci-info@npm:3.3.2"
   checksum: 88ce43eb69180dd01bef1968c43ca39ef0ac6fce5d112d8689d9f58c7f239ae568e48b9097a1315866b66af46fd0158133258c1df0ecd672c99bdee580c25e66
+  languageName: node
+  linkType: hard
+
+"cipher-base@npm:^1.0.0, cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "cipher-base@npm:1.0.4"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 172fced8856f309407e10e2d6dbf0e31a67047267ec1d9ee62f595ab7edfe8e64734434799af09fa1f64f9908f272cdc623a2c2e26de525646c1beee6c263ab9
+  languageName: node
+  linkType: hard
+
+"class-utils@npm:^0.3.5":
+  version: 0.3.6
+  resolution: "class-utils@npm:0.3.6"
+  dependencies:
+    arr-union: "npm:^3.1.0"
+    define-property: "npm:^0.2.5"
+    isobject: "npm:^3.0.0"
+    static-extend: "npm:^0.1.1"
+  checksum: e7fc96034dc63955d303b96c41eaa5728ca86b25aa9a14931d8a440bf7a30c6e7f52837d97337716e24bf74a46e703bbf05eba1b8ef8b67324e61955abc6b0aa
+  languageName: node
+  linkType: hard
+
+"clean-css@npm:^4.2.3":
+  version: 4.2.4
+  resolution: "clean-css@npm:4.2.4"
+  dependencies:
+    source-map: "npm:~0.6.0"
+  checksum: 9d865be87896f53bf919c305a87e8310db27855c229856990f8ad25f35b23ec3fb747e76feb7330783c24d0fd7a38c64b27879d30e6bf6c75b1e14fcec244d30
   languageName: node
   linkType: hard
 
@@ -2259,12 +5927,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-boxes@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "cli-boxes@npm:2.2.1"
+  checksum: a1e6dc8c4c3cacc1f9a265099fc00dc4a4f77485d3f7bcdeecb440d2e632d0e678756ebdfee7e5500f2104deccfa0ea9585d76a84cc92ab4ed96939ef12c0c65
+  languageName: node
+  linkType: hard
+
 "cli-cursor@npm:^3.1.0":
   version: 3.1.0
   resolution: "cli-cursor@npm:3.1.0"
   dependencies:
     restore-cursor: "npm:^3.1.0"
   checksum: 953cdb0291450958e4745da72c078865555c4cce31d48681a51266d14c44ab0641d819762044fd25d6220eebbc878a38acfad913d633eafd3403f9637b1ba4b0
+  languageName: node
+  linkType: hard
+
+"cli-table3@npm:^0.6.1":
+  version: 0.6.2
+  resolution: "cli-table3@npm:0.6.2"
+  dependencies:
+    "@colors/colors": "npm:1.5.0"
+    string-width: "npm:^4.2.0"
+  dependenciesMeta:
+    "@colors/colors":
+      optional: true
+  checksum: dcee6d33413bc64856f709273b693cd639c464c97fb6c4dd33556fa80f107688f004a2e8c9b4e7972796e7819ad86ed616dff26d3dae7be5523c73222a437f45
   languageName: node
   linkType: hard
 
@@ -2296,6 +5984,34 @@ __metadata:
     strip-ansi: "npm:^6.0.0"
     wrap-ansi: "npm:^7.0.0"
   checksum: 11f16da76b7dc4a78bce29ea89445e2ad30cc7cf78954813095d187cc17924461cf42f941d481cd920ab1672221c709af677436179d6cb87f6176139117664aa
+  languageName: node
+  linkType: hard
+
+"clone-deep@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "clone-deep@npm:4.0.1"
+  dependencies:
+    is-plain-object: "npm:^2.0.4"
+    kind-of: "npm:^6.0.2"
+    shallow-clone: "npm:^3.0.0"
+  checksum: 228bea0184f809b1d525a7c4fa522b35cb2916bb841122507d7be4e6503d8a3382a0a4804cfeae61243cfd8a337959fed9b90daed6f7efbf9d53e478d1f23649
+  languageName: node
+  linkType: hard
+
+"collapse-white-space@npm:^1.0.2":
+  version: 1.0.6
+  resolution: "collapse-white-space@npm:1.0.6"
+  checksum: e6562398963c9e4d33292776f7cf94052a392ea5917bcdd6e1b37871cfecef552c84e829c21a2a02b8c27966890a2808825003717891f5c7132d4516107e3436
+  languageName: node
+  linkType: hard
+
+"collection-visit@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "collection-visit@npm:1.0.0"
+  dependencies:
+    map-visit: "npm:^1.0.0"
+    object-visit: "npm:^1.0.0"
+  checksum: 5a9b46e9300bb9b54ff3864cbe23c62597e330351e003b1da785b96cb147f1e3e00113b9e56a2524bba86b5ad2705a9ebae67c600227b025265c304c59581736
   languageName: node
   linkType: hard
 
@@ -2331,7 +6047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-support@npm:^1.1.3":
+"color-support@npm:^1.1.2, color-support@npm:^1.1.3":
   version: 1.1.3
   resolution: "color-support@npm:1.1.3"
   bin:
@@ -2356,10 +6072,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"comma-separated-tokens@npm:^1.0.0":
+  version: 1.0.8
+  resolution: "comma-separated-tokens@npm:1.0.8"
+  checksum: ceccc2cf3f3e5f9f6dcc9861f526addaaf4f7a52150a290c647e26e1f78e949ee55776782422441dec68f7ea6bfc39420ba7cb7e551e5005de8db73640010914
+  languageName: node
+  linkType: hard
+
 "commander@npm:9.4.0, commander@npm:^9.3.0, commander@npm:^9.4.0":
   version: 9.4.0
   resolution: "commander@npm:9.4.0"
   checksum: b1a41144b2e6875163df93dee54c446f2c086d7c8176febaca87ee2b4b177398de3e7b5297e0e70fb2d7ad835398b05c90bc218683daeeece5cef65f9a3a1202
+  languageName: node
+  linkType: hard
+
+"commander@npm:^2.19.0, commander@npm:^2.20.0":
+  version: 2.20.3
+  resolution: "commander@npm:2.20.3"
+  checksum: a6cb7ce73cc1db74a2da4bb6b4fc4f9a655ba35beb90f32bf5831d7d3be610dafc01dcc8a17f8204cf4e3f1f434d2115b7db56dfb0b827d42b10d1ba6ae8cbb4
+  languageName: node
+  linkType: hard
+
+"commander@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "commander@npm:4.1.1"
+  checksum: 3be44d4e8e108ce5056885db1ee90cf34afe5b1c965829c23b3a47890d27980e101889fe7355accd6ec22cad862abc9f609da6de0c4c061e19d04d098611baf4
+  languageName: node
+  linkType: hard
+
+"commander@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "commander@npm:6.2.1"
+  checksum: c52b3cba040d015dc2788bed08041dd2e4734bc79b4ac0e1829544fa09e0844b746b956e9f5f87dee4f62870ab63239f22e2e2d30b242eef392df1501dee319d
   languageName: node
   linkType: hard
 
@@ -2383,6 +6127,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"common-path-prefix@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "common-path-prefix@npm:3.0.0"
+  checksum: 81d3f07d3a70fc2fffe6c1d3c1a207e84f176ea02ce045d80d08379ecb6cfcd4b285cf2f5dc97244e01fe11610295af3bfea26fae7c9cbc5f81bee3bd02e15ec
+  languageName: node
+  linkType: hard
+
 "commondir@npm:^1.0.1":
   version: 1.0.1
   resolution: "commondir@npm:1.0.1"
@@ -2400,10 +6151,53 @@ __metadata:
   languageName: node
   linkType: hard
 
+"component-emitter@npm:^1.2.1":
+  version: 1.3.0
+  resolution: "component-emitter@npm:1.3.0"
+  checksum: e24c33abfa9686ae480530207bf4fe1f096f307f2ad9126500e6c460b76b9c7dd648bc2c7b9eb10d622db69ff53f6f7ee65823719e3d94de301c80e1e944288c
+  languageName: node
+  linkType: hard
+
+"compressible@npm:~2.0.16":
+  version: 2.0.18
+  resolution: "compressible@npm:2.0.18"
+  dependencies:
+    mime-db: "npm:>= 1.43.0 < 2"
+  checksum: 432d82fd41cd3fde227cde779ef4a25d73b63e4ec19de2bd513ad6bfad7649aec9df94832b7695896b55922d8cf345bba4919cf716852fb4d28c92274ee3280a
+  languageName: node
+  linkType: hard
+
+"compression@npm:^1.7.4":
+  version: 1.7.4
+  resolution: "compression@npm:1.7.4"
+  dependencies:
+    accepts: "npm:~1.3.5"
+    bytes: "npm:3.0.0"
+    compressible: "npm:~2.0.16"
+    debug: "npm:2.6.9"
+    on-headers: "npm:~1.0.2"
+    safe-buffer: "npm:5.1.2"
+    vary: "npm:~1.1.2"
+  checksum: 950328121faf22e253580d3e2af6f1c1320b2d38e5bcc93bf87b9a1906d3d89fbc3e380af756c09323cd6c839cac7e605b8f0d54ae7abb55dfe82658002e76e3
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
   checksum: 88222f18b3a68b71fe4473a146c8ed3315ec0488703104319c53543ad4668af3e79418ab79e2fa8032ee04c3eb45cc478815b89877a048cc5ba34e201bc15c35
+  languageName: node
+  linkType: hard
+
+"concat-stream@npm:^1.5.0":
+  version: 1.6.2
+  resolution: "concat-stream@npm:1.6.2"
+  dependencies:
+    buffer-from: "npm:^1.0.0"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^2.2.2"
+    typedarray: "npm:^0.0.6"
+  checksum: 4695f901d58390c9f9b3ce39d81d24a3a3d4e05c2d14cdea3d7c0c77d04133670e26e71faa1b94dc4e5adb72cbb14d4ea8bf50b82e94aff974dbf0d40f01dd1a
   languageName: node
   linkType: hard
 
@@ -2421,29 +6215,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"connect@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "connect@npm:3.7.0"
-  dependencies:
-    debug: "npm:2.6.9"
-    finalhandler: "npm:1.1.2"
-    parseurl: "npm:~1.3.3"
-    utils-merge: "npm:1.0.1"
-  checksum: e9ac05b05312224a89d9030542a4fec1bc4848dab8aba271d33cbfa04fcb84c19d4ce1e9a716a861d69cfbd8f494167d583b8e0a35c485bd9e504310633329ef
-  languageName: node
-  linkType: hard
-
-"consola@npm:2.15.3":
+"consola@npm:^2.15.3":
   version: 2.15.3
   resolution: "consola@npm:2.15.3"
   checksum: 3367f6bd137f1bc82d4585a93ca3c80c0cb4c8c9092a13ca5408401e78250d2bcc6c787e98e007d630d6d1ab0aa7447fb7ef8c5502898bbc36d6e3917d0d8a49
   languageName: node
   linkType: hard
 
-"console-control-strings@npm:^1.1.0":
+"console-browserify@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "console-browserify@npm:1.2.0"
+  checksum: 53a951919e25138f52ef7d406fd76b13783bd047dbe27a44f06673ea00cff6be0103adbf04afce3e4f162202877f29a3202582d13ce478b004cf7663769d3d3c
+  languageName: node
+  linkType: hard
+
+"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: d286ffd439aac97472557325e6aa4cc3a2eefe495a70a9640b89508880db4bba1bd1b29bb011608c23033d884c84cac8da95c8f12ca0ec69ccc70d6d5f39c618
+  languageName: node
+  linkType: hard
+
+"constants-browserify@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "constants-browserify@npm:1.0.0"
+  checksum: 89cb90ef9393e32e4dc79ae9bfd50750b697d2f749dde383d605d141a6f413fa5c7a0cb72a018826f2f5e3ae854ab82e997b170b3a3d6dae065e7817129af382
+  languageName: node
+  linkType: hard
+
+"content-disposition@npm:0.5.4":
+  version: 0.5.4
+  resolution: "content-disposition@npm:0.5.4"
+  dependencies:
+    safe-buffer: "npm:5.2.1"
+  checksum: d38295838d0d136bf434c58deb24b574d66486234832bc97be293d0bd2350acb95a548def1071817346facde253f352f48e7d4ee187f08995b9a6c8317361a5c
+  languageName: node
+  linkType: hard
+
+"content-type@npm:~1.0.4":
+  version: 1.0.4
+  resolution: "content-type@npm:1.0.4"
+  checksum: 20bda9bccfb0086d4e4b35cc5c6073b693d4a8ff0a0da0b68cf283c34a649a5d07068fd240c1ed503a7696dbbf4c875cecb708ea219db1880fbfa40e8fb02620
   languageName: node
   linkType: hard
 
@@ -2484,7 +6296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"convert-source-map@npm:^1.7.0":
+"convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
   version: 1.8.0
   resolution: "convert-source-map@npm:1.8.0"
   dependencies:
@@ -2493,7 +6305,66 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-util-is@npm:^1.0.3":
+"cookie-signature@npm:1.0.6":
+  version: 1.0.6
+  resolution: "cookie-signature@npm:1.0.6"
+  checksum: b99cb14f01bd69029eba0a24f3468034a590ff9ca048dcd37dcb344be2edf8691de8bbef8acffbadc2c5b38f6064fd7eb79714054458f6b714af3e25a884a9f5
+  languageName: node
+  linkType: hard
+
+"cookie@npm:0.5.0":
+  version: 0.5.0
+  resolution: "cookie@npm:0.5.0"
+  checksum: 23bd6dd64f025869373c6f3c72a870b9bd0e0e6a0ffe734229c032d7aca51972ba584b39100c09141b18043e790862425aae4a60d7449fca565b21cdae0cb3c3
+  languageName: node
+  linkType: hard
+
+"copy-concurrently@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "copy-concurrently@npm:1.0.5"
+  dependencies:
+    aproba: "npm:^1.1.1"
+    fs-write-stream-atomic: "npm:^1.0.8"
+    iferr: "npm:^0.1.5"
+    mkdirp: "npm:^0.5.1"
+    rimraf: "npm:^2.5.4"
+    run-queue: "npm:^1.0.0"
+  checksum: 5b634a195b69e660877f777ac07efd25d91369e972d439e551d441b3332eda0d9ccd77e888bdb93d2de697b281d34c02bc1ba953bed926f4b509903f4955c758
+  languageName: node
+  linkType: hard
+
+"copy-descriptor@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "copy-descriptor@npm:0.1.1"
+  checksum: 1115ff4bee07bf9dde218367cb2c7bc6499efdfdc607d774e7dd4ca414b2d82fd5a4f6085867ac4ce480e0ee7fcc1131062e873b85316699bbef4edbc28e54f9
+  languageName: node
+  linkType: hard
+
+"core-js-compat@npm:^3.21.0, core-js-compat@npm:^3.22.1, core-js-compat@npm:^3.8.1":
+  version: 3.24.0
+  resolution: "core-js-compat@npm:3.24.0"
+  dependencies:
+    browserslist: "npm:^4.21.2"
+    semver: "npm:7.0.0"
+  checksum: 8331ec876cb9c614795c678118fd0a9c7eeae49222b5ee60fd372ab3d98910b850c018a59c07258bcf2f8ea229b51eca57b14ab19d95783ed72bf8ddf00acdb9
+  languageName: node
+  linkType: hard
+
+"core-js-pure@npm:^3.8.1":
+  version: 3.24.0
+  resolution: "core-js-pure@npm:3.24.0"
+  checksum: 8d0d38d59b99b7360bec319d51f6361a0c5eca686ab7fe7b467675deb62dd5af65e037df8079500035c87c298a02660701e89d905dde2815dbeb546355340145
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.0.4, core-js@npm:^3.6.5, core-js@npm:^3.8.2":
+  version: 3.24.0
+  resolution: "core-js@npm:3.24.0"
+  checksum: 63ca7a0710a0b7e4d3922d917fb7c7fd10e79121c24e229c440930c06c37c19bec087c73bb6328de9242cf1c7e68f1485945499a1d54b63d0b304d643a7209f7
+  languageName: node
+  linkType: hard
+
+"core-util-is@npm:^1.0.3, core-util-is@npm:~1.0.0":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
   checksum: 3bd2c52819a46215dbe36b3686ec77a7897dcb288eedf217c352451f0e53c131426d191dca4d06f554e8abdcf4b75a8d0ceec85c25126c762e8fd89292f7e4c9
@@ -2514,6 +6385,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "cosmiconfig@npm:6.0.0"
+  dependencies:
+    "@types/parse-json": "npm:^4.0.0"
+    import-fresh: "npm:^3.1.0"
+    parse-json: "npm:^5.0.0"
+    path-type: "npm:^4.0.0"
+    yaml: "npm:^1.7.2"
+  checksum: ff735356e34a9a096fef345cb922949a694681c9fc487355750e97bab3b16da00f3f143a9df57379385583d46010c28bc9c3efc4dcadb66e6da19df01fa66baa
+  languageName: node
+  linkType: hard
+
 "cosmiconfig@npm:^7, cosmiconfig@npm:^7.0.0, cosmiconfig@npm:^7.0.1":
   version: 7.0.1
   resolution: "cosmiconfig@npm:7.0.1"
@@ -2524,6 +6408,72 @@ __metadata:
     path-type: "npm:^4.0.0"
     yaml: "npm:^1.10.0"
   checksum: f5b0588faeb39d1bcb846504cb6693121bf6af4d09a5a0523a9201d189a769a067db33e36d6c6fe23937cc24f9771ad0e76ecb3056a4e244697867d62aa50ec0
+  languageName: node
+  linkType: hard
+
+"cp-file@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "cp-file@npm:7.0.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.2"
+    make-dir: "npm:^3.0.0"
+    nested-error-stacks: "npm:^2.0.0"
+    p-event: "npm:^4.1.0"
+  checksum: 5ad1a7412acbba0d5c1bdbe7d101d4445d656da179ed3595faa7fe013d97b2d7f2d9a3a1b67b228ab9d3e973929c815af8427fe1c878b76b7b0ec4c55ef8b968
+  languageName: node
+  linkType: hard
+
+"cpy@npm:^8.1.2":
+  version: 8.1.2
+  resolution: "cpy@npm:8.1.2"
+  dependencies:
+    arrify: "npm:^2.0.1"
+    cp-file: "npm:^7.0.0"
+    globby: "npm:^9.2.0"
+    has-glob: "npm:^1.0.0"
+    junk: "npm:^3.1.0"
+    nested-error-stacks: "npm:^2.1.0"
+    p-all: "npm:^2.1.0"
+    p-filter: "npm:^2.1.0"
+    p-map: "npm:^3.0.0"
+  checksum: aabb5ccc2f5c91fe380405ad5863cb43eefda3f95effb7e736b8e825ed43de3546af1843b4a8b0d87b48561719f9ed62445dc90029eced93bd78ce37214ae046
+  languageName: node
+  linkType: hard
+
+"create-ecdh@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "create-ecdh@npm:4.0.4"
+  dependencies:
+    bn.js: "npm:^4.1.0"
+    elliptic: "npm:^6.5.3"
+  checksum: 9d6564526a4f7832163b0f3dc40c88ad4b0f2fb68ac3f3f9eb4ebe38b2d73b187ed18f59417fdf31a9b2d7851791632a60c6bd1f024480a4a11668a13b6517ec
+  languageName: node
+  linkType: hard
+
+"create-hash@npm:^1.1.0, create-hash@npm:^1.1.2, create-hash@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "create-hash@npm:1.2.0"
+  dependencies:
+    cipher-base: "npm:^1.0.1"
+    inherits: "npm:^2.0.1"
+    md5.js: "npm:^1.3.4"
+    ripemd160: "npm:^2.0.1"
+    sha.js: "npm:^2.4.0"
+  checksum: a5d13f75066993de16f734b54158594295a9c10643b941e3f2e3bbe72905d716059fd37b05bbfb63b4165a6d6124f204b5a0e4b54b88adf2e03750977c7ca6fd
+  languageName: node
+  linkType: hard
+
+"create-hmac@npm:^1.1.0, create-hmac@npm:^1.1.4, create-hmac@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "create-hmac@npm:1.1.7"
+  dependencies:
+    cipher-base: "npm:^1.0.3"
+    create-hash: "npm:^1.1.0"
+    inherits: "npm:^2.0.1"
+    ripemd160: "npm:^2.0.0"
+    safe-buffer: "npm:^5.0.1"
+    sha.js: "npm:^2.4.8"
+  checksum: 391ca2ff28117042086e16e9343f3ad62c7c2d18221d76d838d3d31e678fa33838c3cda2a645c5189ccf104ca1e35d57aa19e4c5c653ff2c82db8b095851d7f3
   languageName: node
   linkType: hard
 
@@ -2545,6 +6495,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"crypto-browserify@npm:^3.11.0":
+  version: 3.12.0
+  resolution: "crypto-browserify@npm:3.12.0"
+  dependencies:
+    browserify-cipher: "npm:^1.0.0"
+    browserify-sign: "npm:^4.0.0"
+    create-ecdh: "npm:^4.0.0"
+    create-hash: "npm:^1.1.0"
+    create-hmac: "npm:^1.1.0"
+    diffie-hellman: "npm:^5.0.0"
+    inherits: "npm:^2.0.1"
+    pbkdf2: "npm:^3.0.3"
+    public-encrypt: "npm:^4.0.0"
+    randombytes: "npm:^2.0.0"
+    randomfill: "npm:^1.0.3"
+  checksum: 919c1dc2ef93ca4739e8267895034a1fc825fe1cb19d322cb035580ad43098d874b77013dc221e2cf5fe76805092d09bbf5ae839e94055dc61af692fd99d5e7c
+  languageName: node
+  linkType: hard
+
 "crypto-random-string@npm:^2.0.0":
   version: 2.0.0
   resolution: "crypto-random-string@npm:2.0.0"
@@ -2553,63 +6522,63 @@ __metadata:
   linkType: hard
 
 "cspell-gitignore@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "cspell-gitignore@npm:6.4.1"
+  version: 6.4.2
+  resolution: "cspell-gitignore@npm:6.4.2"
   dependencies:
-    cspell-glob: "npm:^6.4.1"
+    cspell-glob: "npm:^6.4.2"
     find-up: "npm:^5.0.0"
   bin:
     cspell-gitignore: bin.js
-  checksum: 3cff3adeaedba810eb6667ca6d5d988f4c0f733b1fe9d33bdea1725d2c6622aae8fc0326c95c27129aa46cc05bb163089a35ba89cd5d4647f9a5e83b270714ff
+  checksum: e66bd393de5274d991a4235fdd559eff1a8676efe9d16b0385ba9c17032cb085d83780db436996b7e965ed96504bfdca600e0316ef4ca091061815afe7661686
   languageName: node
   linkType: hard
 
-"cspell-glob@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "cspell-glob@npm:6.4.1"
+"cspell-glob@npm:^6.4.1, cspell-glob@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "cspell-glob@npm:6.4.2"
   dependencies:
     micromatch: "npm:^4.0.5"
-  checksum: ee97a7ed5d8bd57f5f3ad7e35496811035f9a56fbdc08e7b7901dea378e334576096a0c24b237a7f3d6239569a9ae581efe91a2dfe4dcbc99eed1f68ace665cc
+  checksum: 0eb7da1cae6cf9c10e7545c02b21601a5d5e693e7bcd08f10dfa754273ea874c9eb158dba0ab08731600bd2db4e9cbc7972e14cfbd7fd8dffd59a9cbef189938
   languageName: node
   linkType: hard
 
-"cspell-grammar@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "cspell-grammar@npm:6.4.1"
+"cspell-grammar@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "cspell-grammar@npm:6.4.2"
   dependencies:
-    "@cspell/cspell-pipe": "npm:^6.4.1"
-    "@cspell/cspell-types": "npm:^6.4.1"
+    "@cspell/cspell-pipe": "npm:^6.4.2"
+    "@cspell/cspell-types": "npm:^6.4.2"
   bin:
     cspell-grammar: bin.js
-  checksum: 857f63861027465303a94a28478704409b046ef2b516aa9fffbd910bd878a68328d426795b6cabe177625f6cf45141b8529416a6da3b656c8fdd4aa7f9cdb3d3
+  checksum: d60ba705f3652a751bf52212f59482409f16542b3788421dcffce5b5904ca8142e13023640fedfca36032f82db53b73ea3288c1d882b0f7bd34238c3f8b850c8
   languageName: node
   linkType: hard
 
-"cspell-io@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "cspell-io@npm:6.4.1"
+"cspell-io@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "cspell-io@npm:6.4.2"
   dependencies:
     "@types/node-fetch": "npm:^2.6.2"
     node-fetch: "npm:^2.6.7"
-  checksum: cbc9e31c9da478290284d3898d0504fa9c14db69d984d03e2ad70733a51ada88693a27d79a983869e8aa36d0cb10f3d3ba62947d90956cf805f2e67ac68db6ee
+  checksum: 20011a16ff51a84890a2ecfec159058da961983345e68ed1ee637ffd149f14a3db6ef8eb74934f188883fac39b42b54accca8e35c991290355f453f48162bebd
   languageName: node
   linkType: hard
 
 "cspell-lib@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "cspell-lib@npm:6.4.1"
+  version: 6.4.2
+  resolution: "cspell-lib@npm:6.4.2"
   dependencies:
-    "@cspell/cspell-bundled-dicts": "npm:^6.4.1"
-    "@cspell/cspell-pipe": "npm:^6.4.1"
-    "@cspell/cspell-types": "npm:^6.4.1"
+    "@cspell/cspell-bundled-dicts": "npm:^6.4.2"
+    "@cspell/cspell-pipe": "npm:^6.4.2"
+    "@cspell/cspell-types": "npm:^6.4.2"
     clear-module: "npm:^4.1.2"
     comment-json: "npm:^4.2.2"
     configstore: "npm:^5.0.1"
     cosmiconfig: "npm:^7.0.1"
-    cspell-glob: "npm:^6.4.1"
-    cspell-grammar: "npm:^6.4.1"
-    cspell-io: "npm:^6.4.1"
-    cspell-trie-lib: "npm:^6.4.1"
+    cspell-glob: "npm:^6.4.2"
+    cspell-grammar: "npm:^6.4.2"
+    cspell-io: "npm:^6.4.2"
+    cspell-trie-lib: "npm:^6.4.2"
     fast-equals: "npm:^4.0.1"
     find-up: "npm:^5.0.0"
     fs-extra: "npm:^10.1.0"
@@ -2619,18 +6588,18 @@ __metadata:
     resolve-global: "npm:^1.0.0"
     vscode-languageserver-textdocument: "npm:^1.0.5"
     vscode-uri: "npm:^3.0.3"
-  checksum: 54df4eff9339e03c0ed7519ff1e01873c2017c014089bd4946a87f6a4063e9a06bfb3bfc48ee3e04f4467a830dffb257b9b2f4927e5cd41ea2ea3b4bb1d756d3
+  checksum: 95f9fb41b7673b5ee11f7fda7e30df1354ce6d11f1c0a00aac267177bd23dc8738cae6ca67ba184224dd5f2b141638a521fa4758b530ea938766d837954cdc09
   languageName: node
   linkType: hard
 
-"cspell-trie-lib@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "cspell-trie-lib@npm:6.4.1"
+"cspell-trie-lib@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "cspell-trie-lib@npm:6.4.2"
   dependencies:
-    "@cspell/cspell-pipe": "npm:^6.4.1"
+    "@cspell/cspell-pipe": "npm:^6.4.2"
     fs-extra: "npm:^10.1.0"
     gensequence: "npm:^3.1.1"
-  checksum: 501e454a43abfce3f4f91049f690ca23a70872f3b7a6cbf803ceab0b9c3f2916f07034c8a26e587bca41426132e5a5e6da7d7983b7738833309955e73830b6e5
+  checksum: f195984d576a5ab2daa0d3b8fe54390794049d2715a571c38d31ad9165735a5a50337c7c56f81aeca6bce6efcfb2685c90ee661447ea1b0c9917f3cd4a2e7e91
   languageName: node
   linkType: hard
 
@@ -2659,10 +6628,96 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-color-keywords@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "css-color-keywords@npm:1.0.0"
+  checksum: f82ad50222db625376d7764278e5fda43c58be64568d739c05e1406b4c74dfa376bb0bbee273cc39e579f65222175ae5d5aa3f9b34cfdcd67aea2d4655ee512f
+  languageName: node
+  linkType: hard
+
+"css-loader@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "css-loader@npm:3.6.0"
+  dependencies:
+    camelcase: "npm:^5.3.1"
+    cssesc: "npm:^3.0.0"
+    icss-utils: "npm:^4.1.1"
+    loader-utils: "npm:^1.2.3"
+    normalize-path: "npm:^3.0.0"
+    postcss: "npm:^7.0.32"
+    postcss-modules-extract-imports: "npm:^2.0.0"
+    postcss-modules-local-by-default: "npm:^3.0.2"
+    postcss-modules-scope: "npm:^2.2.0"
+    postcss-modules-values: "npm:^3.0.0"
+    postcss-value-parser: "npm:^4.1.0"
+    schema-utils: "npm:^2.7.0"
+    semver: "npm:^6.3.0"
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 24f5214aebe4049521e3cbbfe676a04ac16ab3188fd876a5ae3cf65b4d15d679422cc8f3ecbd84d0d4dfb89962bd25e81cc69a093441b84c029525dc3226301f
+  languageName: node
+  linkType: hard
+
+"css-select@npm:^4.1.3":
+  version: 4.3.0
+  resolution: "css-select@npm:4.3.0"
+  dependencies:
+    boolbase: "npm:^1.0.0"
+    css-what: "npm:^6.0.1"
+    domhandler: "npm:^4.3.1"
+    domutils: "npm:^2.8.0"
+    nth-check: "npm:^2.0.1"
+  checksum: 6d1ba269fa77ef2bf831e20d9acc020c8f6eb8ffabd30123a8c03b47f813ed69ea8371239ddea88163f207e0e085eaf44fcbdb6a2763a226c10e76934ffa7ffc
+  languageName: node
+  linkType: hard
+
+"css-to-react-native@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "css-to-react-native@npm:3.0.0"
+  dependencies:
+    camelize: "npm:^1.0.0"
+    css-color-keywords: "npm:^1.0.0"
+    postcss-value-parser: "npm:^4.0.2"
+  checksum: 424d600adb0915b4a9958d60488d58dc0a1d1445dfaf638fd117918c0be5c549393d15655a62353cbb4e7d9e4ceaebd1acf2c0cc14dfe67eebf9f5de44f2eb03
+  languageName: node
+  linkType: hard
+
+"css-what@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "css-what@npm:6.1.0"
+  checksum: 60dfd497e518f5d7ff78a5091ad21c610e2c58c3463ad3191ef7e22a51d01fc0c3401d8bac55f511f119d14c3dcf606f1e37f1590274003722055dee849e2302
+  languageName: node
+  linkType: hard
+
+"cssesc@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cssesc@npm:3.0.0"
+  bin:
+    cssesc: bin/cssesc
+  checksum: 5e8fcfb6a0fa7f9c05fd6d5a6a6580586310c7dd85c3938e1f199736fd392a9317998e639fde58f63ea786ff1bae5078d6342321c1deddab595fc5bf1764e66e
+  languageName: node
+  linkType: hard
+
 "csstype@npm:^3.0.2":
   version: 3.1.0
   resolution: "csstype@npm:3.1.0"
   checksum: fbe7e1dfc64482b370e5ceead6158636dc1eb76b4e6a6d328360548c1951c14e6bbc0516533b58faba4d40ced409324393ffd843febc4bb60302a64692e46788
+  languageName: node
+  linkType: hard
+
+"currently-unhandled@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "currently-unhandled@npm:0.4.1"
+  dependencies:
+    array-find-index: "npm:^1.0.1"
+  checksum: d32c964139dd2e357fb6947cea6db2d3a8a672b21ec9e6ba81d3518f49139de0510b77e4736b2173af084f2f885fd4c7420c97c840cf957c2a154e0b64a17a15
+  languageName: node
+  linkType: hard
+
+"cyclist@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "cyclist@npm:1.0.1"
+  checksum: 7cb16a1e4310ed56c083956b76719bad9308dd1fcae419ca3588054ef8434d8c48152b797dd53b2660c39b13296f72896443b3590b6a972ec377a931562bcfad
   languageName: node
   linkType: hard
 
@@ -2673,7 +6728,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:2.6.9":
+"debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.3.3, debug@npm:^2.6.0":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -2694,6 +6749,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^3.0.0":
+  version: 3.2.7
+  resolution: "debug@npm:3.2.7"
+  dependencies:
+    ms: "npm:^2.1.1"
+  checksum: b98f479c1004d349128ba45f38fb1af53fa3ab1a3614f27c56e2cfbee34b58cbf7dc060fead0882a5b64924e49d1dd59fb796a5d90ba7b1987d72d426e199253
+  languageName: node
+  linkType: hard
+
 "decamelize-keys@npm:^1.1.0":
   version: 1.1.0
   resolution: "decamelize-keys@npm:1.1.0"
@@ -2704,7 +6768,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:^1.1.0":
+"decamelize@npm:^1.1.0, decamelize@npm:^1.1.2":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 78728512bf37e5c8d093bf375191b808d54bea424d3cf61730d4c00fe11f404bde37c02e5bd28da7d4981411a4c5369e67a72d92b038126ddf5e5fcc0d03b645
@@ -2718,6 +6782,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decode-uri-component@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "decode-uri-component@npm:0.2.0"
+  checksum: 6944873192e84e58c4fd6483ce8846f2907b4ab1f0170a44bcc259fd976b7f6eecaad2016c9ada00a75155692b443f7970036c60a4d78853d0a0e2bec6f55ec8
+  languageName: node
+  linkType: hard
+
+"dedent@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "dedent@npm:0.7.0"
+  checksum: ca3f1755ff26262fd43c339faafd3e92c1b3265b132397fc702d97643173fc03f35209af8f93583a99f878c6a355300971dbd2a27e7e0a4af4380c7b38d907ae
+  languageName: node
+  linkType: hard
+
 "deep-eql@npm:^3.0.1":
   version: 3.0.1
   resolution: "deep-eql@npm:3.0.1"
@@ -2727,7 +6805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-is@npm:^0.1.3":
+"deep-is@npm:^0.1.3, deep-is@npm:~0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
   checksum: dfee7fc148cb00508a2a4af815144cce85a86ec7a5f658525bf6929095baeef7782c166504a0dc3b18872a1f53e27521de3d308a575c6d8063516815fc553a59
@@ -2741,13 +6819,61 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.1.3, define-properties@npm:^1.1.4":
+"default-browser-id@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "default-browser-id@npm:1.0.4"
+  dependencies:
+    bplist-parser: "npm:^0.1.0"
+    meow: "npm:^3.1.0"
+    untildify: "npm:^2.0.0"
+  bin:
+    default-browser-id: cli.js
+  checksum: ca203cd27d7737ba7780bff662b0179ba2d8169d2edac116ec4bcd15988689953faf979c13c32d74c11f6a112d6660bb0e11c6787de5a868746240024ce21c73
+  languageName: node
+  linkType: hard
+
+"define-lazy-prop@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "define-lazy-prop@npm:2.0.0"
+  checksum: 53656037e7b33e52c0cb39d8348c92087b961711c89fa7df07e6c8cfe5039d17157ee8e22c00bbdd4d1038a114f2d38821fcef4668d4c87854635ec13e87b808
+  languageName: node
+  linkType: hard
+
+"define-properties@npm:^1.1.2, define-properties@npm:^1.1.3, define-properties@npm:^1.1.4":
   version: 1.1.4
   resolution: "define-properties@npm:1.1.4"
   dependencies:
     has-property-descriptors: "npm:^1.0.0"
     object-keys: "npm:^1.1.1"
   checksum: 94a6a24f787300c11c53b76e207e53908c86fd508f0dacf0bab49afff62b20439513e14318cebdb3223eef7a49d572eaf7f069a21af80e3ca3f898bbf22c9c8e
+  languageName: node
+  linkType: hard
+
+"define-property@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "define-property@npm:0.2.5"
+  dependencies:
+    is-descriptor: "npm:^0.1.0"
+  checksum: 56115d676e058b5190caa7c21251ae01d2b21360972df782e7942676ca0fb8bddd323ebf8cb37cce0ffa19ed2d21212cc0d730d5a27c703a919fc508507c4316
+  languageName: node
+  linkType: hard
+
+"define-property@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "define-property@npm:1.0.0"
+  dependencies:
+    is-descriptor: "npm:^1.0.0"
+  checksum: cbe268428a690cb006cab599a868688578e2ed40fd4323a14029281df82d6b1313061c824d9ac9ad609f2e84d8759264fe06c989505ae4ced5836e9cefb0d245
+  languageName: node
+  linkType: hard
+
+"define-property@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "define-property@npm:2.0.2"
+  dependencies:
+    is-descriptor: "npm:^1.0.2"
+    isobject: "npm:^3.0.1"
+  checksum: 6251ba95705ad29d6ea71aa8681ebcdee3ae1763f5406def305f939868f542ea213ff86f51c0959289238ab443ad5660c2a81e5b91f48d727ee743a10e7553af
   languageName: node
   linkType: hard
 
@@ -2772,10 +6898,65 @@ __metadata:
   languageName: node
   linkType: hard
 
+"depd@npm:2.0.0":
+  version: 2.0.0
+  resolution: "depd@npm:2.0.0"
+  checksum: 170e90bfa90081462303140623fdf938aeba2f066b1c7a9a1c599b257ea8127d36b9d39fad5a9d71f5282a3bb5a8ca287ce4d8c6cecd0f65e6bf3779cc6091be
+  languageName: node
+  linkType: hard
+
 "depd@npm:^1.1.2":
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
   checksum: e9fb93771e7cf3d88c4e38ca95742f7c58cae31928eb5e67a1a14d970325a02755451bb7fafc2db72333a5cf7fc14e07e4f8d709c0df70143355e77e8d090bac
+  languageName: node
+  linkType: hard
+
+"des.js@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "des.js@npm:1.0.1"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    minimalistic-assert: "npm:^1.0.0"
+  checksum: db332d75d1ac2085378ff84c9c12ccb2705aeda0f5e6253bb85f3b6e6235682d11231f83e485a12ef2f1c2dee8680289ec930d2b3efdc796750d30967fdd7d9d
+  languageName: node
+  linkType: hard
+
+"destroy@npm:1.2.0":
+  version: 1.2.0
+  resolution: "destroy@npm:1.2.0"
+  checksum: dc7c93cc92fefb26b1fd5251603da79b0289d06b6891743cb16ac11564aaf0cc985e89efb663322a39a477c4c7f2da51321bf82bb513280a12171cef63b60a21
+  languageName: node
+  linkType: hard
+
+"detab@npm:2.0.4":
+  version: 2.0.4
+  resolution: "detab@npm:2.0.4"
+  dependencies:
+    repeat-string: "npm:^1.5.4"
+  checksum: 64037b904c96978886b0c5feaae940434ce81213421bad110c665aadad3cfa516b9547b68fdf0b6e11376b15f702526ac829438da2dad0aab2d7bcb681149953
+  languageName: node
+  linkType: hard
+
+"detect-package-manager@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "detect-package-manager@npm:2.0.1"
+  dependencies:
+    execa: "npm:^5.1.1"
+  checksum: ab561e19bc47c1bdebfaa3ca2b5ae83ca4c97909d46085af36ab2d928a55851a9f93517508d42c959a86671b0429d5a22169d8dd41663688d684defdccf8a9e6
+  languageName: node
+  linkType: hard
+
+"detect-port@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "detect-port@npm:1.3.0"
+  dependencies:
+    address: "npm:^1.0.1"
+    debug: "npm:^2.6.0"
+  bin:
+    detect: ./bin/detect-port
+    detect-port: ./bin/detect-port
+  checksum: cc05a38ceeb942a0d5801fa2321885c2a81a0728ab793113c5edd3e602f23cd183241a4bb230895e886c20cb09f7ca04dc95a0c4a255afe7336ffe995f6b818d
   languageName: node
   linkType: hard
 
@@ -2786,7 +6967,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dir-glob@npm:^2.0.0":
+"diffie-hellman@npm:^5.0.0":
+  version: 5.0.3
+  resolution: "diffie-hellman@npm:5.0.3"
+  dependencies:
+    bn.js: "npm:^4.1.0"
+    miller-rabin: "npm:^4.0.0"
+    randombytes: "npm:^2.0.0"
+  checksum: e8fa8362bfe35862da10d9d9775c38ac769fe9c7c70248c641efbd4efca9f2b26af4eee21cbdc0fa197066eca0b932b798fc67bf027541c2a739d4c4d9569b01
+  languageName: node
+  linkType: hard
+
+"dir-glob@npm:^2.0.0, dir-glob@npm:^2.2.2":
   version: 2.2.2
   resolution: "dir-glob@npm:2.2.2"
   dependencies:
@@ -2822,12 +7014,109 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-converter@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "dom-converter@npm:0.2.0"
+  dependencies:
+    utila: "npm:~0.4"
+  checksum: b5d6077b38c45332f04846052849115cbd424303c43ae0cbc6b4ad97ce088788cc5abc2e9a28ecda38a1e1170a924799183a463aed88ebe07d6468739b65bc19
+  languageName: node
+  linkType: hard
+
+"dom-serializer@npm:^1.0.1":
+  version: 1.4.1
+  resolution: "dom-serializer@npm:1.4.1"
+  dependencies:
+    domelementtype: "npm:^2.0.1"
+    domhandler: "npm:^4.2.0"
+    entities: "npm:^2.0.0"
+  checksum: 94f1d57ee01a9bb1f8f82b83484de837daa89fd99e66356f9e92c9e936c7acdc7902386320edf4d3340cd3fa116d0e9553b0cca6a94df6562aa0f4661b63c322
+  languageName: node
+  linkType: hard
+
+"dom-walk@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "dom-walk@npm:0.1.2"
+  checksum: d1cb40e62dd73d55797ee4c16798159f4bfd88bbe5491aafd3f19cf9e5a44cac5c2d6511d10afd890bc6c6b18864bd8aa90d9fb17f6ab4c3d2ceb03c884d5f47
+  languageName: node
+  linkType: hard
+
+"domain-browser@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "domain-browser@npm:1.2.0"
+  checksum: 15a8c14a7701aba81f48db3e93ac758a11b774c4134517f6ee63c79287f29797da67b1bbfd982f430f833eac6404ce01144780db0505fef7ca4e813d2848939f
+  languageName: node
+  linkType: hard
+
+"domelementtype@npm:^2.0.1, domelementtype@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "domelementtype@npm:2.3.0"
+  checksum: 07afcb90734e39b324e19271effc13389bb27a3957fa68a99b19d0ffdc0338fe669e9170a876f0fc4948bedd28b1f937042ada4948bee54e01a833c37a54dd74
+  languageName: node
+  linkType: hard
+
+"domhandler@npm:^4.0.0, domhandler@npm:^4.2.0, domhandler@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "domhandler@npm:4.3.1"
+  dependencies:
+    domelementtype: "npm:^2.2.0"
+  checksum: bc5b81fc04a2ebdc9ff971cec46382c00c2dfe488635f0e00b56ee18e78d3da5c0a4388cad802dbb93219e5d39efdba42107214dbea7d9db8325b8c2793cbb5a
+  languageName: node
+  linkType: hard
+
+"domutils@npm:^2.5.2, domutils@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "domutils@npm:2.8.0"
+  dependencies:
+    dom-serializer: "npm:^1.0.1"
+    domelementtype: "npm:^2.2.0"
+    domhandler: "npm:^4.2.0"
+  checksum: 7d3ccd2fa5046b263d6080ae7584f41c2b1e1a9b60b0ed333d6f5a0ba35ccd182fabfe380185bca020e29d9c2cffabde75dec654eda260aaebf63ac1df82ed5c
+  languageName: node
+  linkType: hard
+
+"dot-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "dot-case@npm:3.0.4"
+  dependencies:
+    no-case: "npm:^3.0.4"
+    tslib: "npm:^2.0.3"
+  checksum: 951f9f8423106c57ba5f078e5d81cf810a94d20b16e50ea26369942b634bb30789677756a267320907b250b8c0432b598da719ade592c727968bb1f8cfefa8c6
+  languageName: node
+  linkType: hard
+
 "dot-prop@npm:^5.1.0, dot-prop@npm:^5.2.0":
   version: 5.3.0
   resolution: "dot-prop@npm:5.3.0"
   dependencies:
     is-obj: "npm:^2.0.0"
   checksum: 640302936faf887e4772e97f33efdc1d12adc33183503497687f0400ef832f1596e81f19a9d0f641a8e3312e9cbaa1a5d6620783dda0113871064dc9dec4a30d
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "dotenv-expand@npm:5.1.0"
+  checksum: 45ac32cdf6e194ed587ffc87745d3bacc8a831b73d70fef5c4d86294b4eb2e441b745df8fc031df38f5772276ec0f4af74999f4ff5d4e48b1f98cab3b720f394
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^8.0.0":
+  version: 8.6.0
+  resolution: "dotenv@npm:8.6.0"
+  checksum: a58180cbaa6b7edec539461e4fd72fc9f2b7a181187a2e10942f047da15316f90f04eeeb18b7137049c6e5035a3451af103ddd7a8c691eac339d4e48e1bb1a08
+  languageName: node
+  linkType: hard
+
+"duplexify@npm:^3.4.2, duplexify@npm:^3.6.0":
+  version: 3.7.1
+  resolution: "duplexify@npm:3.7.1"
+  dependencies:
+    end-of-stream: "npm:^1.0.0"
+    inherits: "npm:^2.0.1"
+    readable-stream: "npm:^2.0.0"
+    stream-shift: "npm:^1.0.0"
+  checksum: a1e739c4fc538295b22f118440be19484a0bd109983324fcb5d74e3448a41d3b0656270a30430494826acec8254171d57e3f2b51118f66d8f39d0f8e68192835
   languageName: node
   linkType: hard
 
@@ -2845,10 +7134,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.188":
-  version: 1.4.200
-  resolution: "electron-to-chromium@npm:1.4.200"
-  checksum: a6ea294686ab0e0797c7a2630646388e979affe66c370548c57a66c7087413a69ad35bfe2c440238898da7dc9bbeb0f733693dec0f2554fb37839c8086567dc6
+"electron-to-chromium@npm:^1.4.202":
+  version: 1.4.205
+  resolution: "electron-to-chromium@npm:1.4.205"
+  checksum: 76be4d1ff06459191f05ba511fdc4f158643d475c9fc05e63eac463825d727316df31cbac2c172c4c9d28c326a3f1219f2e62fe27e3a0a1b157dc4d019661328
+  languageName: node
+  linkType: hard
+
+"elliptic@npm:^6.5.3":
+  version: 6.5.4
+  resolution: "elliptic@npm:6.5.4"
+  dependencies:
+    bn.js: "npm:^4.11.9"
+    brorand: "npm:^1.1.0"
+    hash.js: "npm:^1.0.0"
+    hmac-drbg: "npm:^1.0.1"
+    inherits: "npm:^2.0.4"
+    minimalistic-assert: "npm:^1.0.1"
+    minimalistic-crypto-utils: "npm:^1.0.1"
+  checksum: 4453b008cf9e741a87f8e1935398c10124291026e7f2b99a512205a645c59586deaeefbb1e7149574481ec2c4cc7f34efc6ae6ae5bc35a94431be71c0375367e
   languageName: node
   linkType: hard
 
@@ -2863,6 +7167,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: ef0642d76f5116a04296a85ec167696b91ca8a1373d3cd13ec3acfb0f6a77d4d1c6ce94192ab31f8bad5ca69fbd01b556638fdf389128fea48fb5f6c2c754b45
+  languageName: node
+  linkType: hard
+
+"emojis-list@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "emojis-list@npm:3.0.0"
+  checksum: 1f66a09f99099edd85d04c6f66d6c826a9c8c7af09c5aeb0be2eda236e7e2269fa6459e6eec404886810c46bd935a7e859e731adccb1ee127b672b706a9f76bc
   languageName: node
   linkType: hard
 
@@ -2882,12 +7193,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.1.0":
+"end-of-stream@npm:^1.0.0, end-of-stream@npm:^1.1.0":
   version: 1.4.4
   resolution: "end-of-stream@npm:1.4.4"
   dependencies:
     once: "npm:^1.4.0"
   checksum: fa73674a01c2e7a3e17c801cb916c1e0c77f2cc719a42cee1bb3ce3550b9425369e4d0a2b2ce6670cb8eff07d34e67333949c83a30e7ec94625cec68aa07664e
+  languageName: node
+  linkType: hard
+
+"endent@npm:^2.0.1":
+  version: 2.1.0
+  resolution: "endent@npm:2.1.0"
+  dependencies:
+    dedent: "npm:^0.7.0"
+    fast-json-parse: "npm:^1.0.3"
+    objectorarray: "npm:^1.0.5"
+  checksum: 9a847a1b55fb9267aa36443b75fecff7f5587f39a886833ff876b22711f0c17483137992b69f6626abe74580100b7302fd00a0ce3c0c9b33608cddb40ae37a4e
+  languageName: node
+  linkType: hard
+
+"enhanced-resolve@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "enhanced-resolve@npm:4.5.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.2"
+    memory-fs: "npm:^0.5.0"
+    tapable: "npm:^1.0.0"
+  checksum: 6484b59cb1ac9b235ad30663b980b8fd41cda5f925a7725fe4b0ae955c571de0bbdecf82b3491e810776b4c083439d32f2ca4f900490cb84b7dad21e33e81747
+  languageName: node
+  linkType: hard
+
+"enhanced-resolve@npm:^5.10.0":
+  version: 5.10.0
+  resolution: "enhanced-resolve@npm:5.10.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    tapable: "npm:^2.2.0"
+  checksum: 97f2cb6318920931b84ea1209b220b7f0324581eef434f16c1df95d1997a4bbd80cceabd6be81465cf450060dee84b265d317ac23276369756b2d8a3ca68e9d6
+  languageName: node
+  linkType: hard
+
+"entities@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "entities@npm:2.2.0"
+  checksum: eec79bcb8fe0e6e8c5fcd83fe87115535a4a616220db35ddec38aac360f0f19669da3150a87f2bd9fba9829cea0857c806ea216177adc3d099b143db9e89d46f
   languageName: node
   linkType: hard
 
@@ -2912,7 +7262,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"error-ex@npm:^1.3.1":
+"errno@npm:^0.1.3, errno@npm:~0.1.7":
+  version: 0.1.8
+  resolution: "errno@npm:0.1.8"
+  dependencies:
+    prr: "npm:~1.0.1"
+  bin:
+    errno: cli.js
+  checksum: 8897270c7ba0fefd8eb1ae0852324efbfcb2f2d85025f6c36411605f1f1fc1330431d7a06b407fd0dbe3f051948d67574e100aea984400221c4a09f690098e4a
+  languageName: node
+  linkType: hard
+
+"error-ex@npm:^1.2.0, error-ex@npm:^1.3.1":
   version: 1.3.2
   resolution: "error-ex@npm:1.3.2"
   dependencies:
@@ -2921,7 +7282,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.19.0, es-abstract@npm:^1.19.1, es-abstract@npm:^1.19.2, es-abstract@npm:^1.19.5":
+"error-stack-parser@npm:^2.0.6":
+  version: 2.1.4
+  resolution: "error-stack-parser@npm:2.1.4"
+  dependencies:
+    stackframe: "npm:^1.3.4"
+  checksum: 032589b1e0d40cd3093d22d8b4f267b017725e1e9593bd50f5a223ffcb7958575da6d8d04657d0ac04b64f4d8f7199e0907b43059fa118b5c451aae6007e0959
+  languageName: node
+  linkType: hard
+
+"es-abstract@npm:^1.19.0, es-abstract@npm:^1.19.1, es-abstract@npm:^1.19.2, es-abstract@npm:^1.19.5, es-abstract@npm:^1.20.1":
   version: 1.20.1
   resolution: "es-abstract@npm:1.20.1"
   dependencies:
@@ -2952,7 +7322,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^0.9.3":
+"es-array-method-boxes-properly@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-array-method-boxes-properly@npm:1.0.0"
+  checksum: 89cdd370a77eba1a5a66dcaeb8f796caaec0ea45644aeecc4a3c4d70e804d0736dcb061d9008def9a9f1780fbcd07eb47d828166e83fc1bb569eab36f596c189
+  languageName: node
+  linkType: hard
+
+"es-get-iterator@npm:^1.0.2":
+  version: 1.1.2
+  resolution: "es-get-iterator@npm:1.1.2"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.1.0"
+    has-symbols: "npm:^1.0.1"
+    is-arguments: "npm:^1.1.0"
+    is-map: "npm:^2.0.2"
+    is-set: "npm:^2.0.2"
+    is-string: "npm:^1.0.5"
+    isarray: "npm:^2.0.5"
+  checksum: 65ec8b2482715444bc92121a2e63d8795ca2026ddc29efaca925eba16331a74b0f3edee0530708932a3710dfe42855a35dd039dc9bb794874ee793ff2cbd1f09
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^0.9.0, es-module-lexer@npm:^0.9.3":
   version: 0.9.3
   resolution: "es-module-lexer@npm:0.9.3"
   checksum: b62592d654c86254adfcf3cc84ac23a5044c4d55ff32981d6871eb91102455daf241f936ebf09caa6573b1a4f16d7d49ee01df163c2da1e1415bbec3564a4e3d
@@ -2979,170 +7372,184 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-android-64@npm:0.14.50"
+"es5-shim@npm:^4.5.13":
+  version: 4.6.7
+  resolution: "es5-shim@npm:4.6.7"
+  checksum: 8ea4c1b75965025b09fc604f8a9da7de358cdcd56526e0fe3d8f560d278930763f79e7acfe7fad492f5678a8d544850cc4eb46955ccefe676cd7fd64083f35ec
+  languageName: node
+  linkType: hard
+
+"es6-shim@npm:^0.35.5":
+  version: 0.35.6
+  resolution: "es6-shim@npm:0.35.6"
+  checksum: 37780ef406be272beab19224aef3be14ada1ca4eb5462af95ad1378d4f86fef0c9d95d9a485191ef324641e29950ba8787d547793e2687855477b2ba3552d673
+  languageName: node
+  linkType: hard
+
+"esbuild-android-64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-android-64@npm:0.14.51"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-android-arm64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-android-arm64@npm:0.14.50"
+"esbuild-android-arm64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-android-arm64@npm:0.14.51"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild-darwin-64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-darwin-64@npm:0.14.50"
+"esbuild-darwin-64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-darwin-64@npm:0.14.51"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-darwin-arm64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-darwin-arm64@npm:0.14.50"
+"esbuild-darwin-arm64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-darwin-arm64@npm:0.14.51"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-freebsd-64@npm:0.14.50"
+"esbuild-freebsd-64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-freebsd-64@npm:0.14.51"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-arm64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-freebsd-arm64@npm:0.14.50"
+"esbuild-freebsd-arm64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-freebsd-arm64@npm:0.14.51"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild-linux-32@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-linux-32@npm:0.14.50"
+"esbuild-linux-32@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-linux-32@npm:0.14.51"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"esbuild-linux-64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-linux-64@npm:0.14.50"
+"esbuild-linux-64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-linux-64@npm:0.14.51"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-linux-arm64@npm:0.14.50"
+"esbuild-linux-arm64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-linux-arm64@npm:0.14.51"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-linux-arm@npm:0.14.50"
+"esbuild-linux-arm@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-linux-arm@npm:0.14.51"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"esbuild-linux-mips64le@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-linux-mips64le@npm:0.14.50"
+"esbuild-linux-mips64le@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-linux-mips64le@npm:0.14.51"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"esbuild-linux-ppc64le@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-linux-ppc64le@npm:0.14.50"
+"esbuild-linux-ppc64le@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-linux-ppc64le@npm:0.14.51"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"esbuild-linux-riscv64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-linux-riscv64@npm:0.14.50"
+"esbuild-linux-riscv64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-linux-riscv64@npm:0.14.51"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"esbuild-linux-s390x@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-linux-s390x@npm:0.14.50"
+"esbuild-linux-s390x@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-linux-s390x@npm:0.14.51"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"esbuild-netbsd-64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-netbsd-64@npm:0.14.50"
+"esbuild-netbsd-64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-netbsd-64@npm:0.14.51"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-openbsd-64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-openbsd-64@npm:0.14.50"
+"esbuild-openbsd-64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-openbsd-64@npm:0.14.51"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-sunos-64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-sunos-64@npm:0.14.50"
+"esbuild-sunos-64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-sunos-64@npm:0.14.51"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-windows-32@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-windows-32@npm:0.14.50"
+"esbuild-windows-32@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-windows-32@npm:0.14.51"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"esbuild-windows-64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-windows-64@npm:0.14.50"
+"esbuild-windows-64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-windows-64@npm:0.14.51"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-windows-arm64@npm:0.14.50":
-  version: 0.14.50
-  resolution: "esbuild-windows-arm64@npm:0.14.50"
+"esbuild-windows-arm64@npm:0.14.51":
+  version: 0.14.51
+  resolution: "esbuild-windows-arm64@npm:0.14.51"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.14.27, esbuild@npm:^0.14.47, esbuild@npm:^0.14.49":
-  version: 0.14.50
-  resolution: "esbuild@npm:0.14.50"
+"esbuild@npm:^0.14.47, esbuild@npm:^0.14.49":
+  version: 0.14.51
+  resolution: "esbuild@npm:0.14.51"
   dependencies:
-    esbuild-android-64: "npm:0.14.50"
-    esbuild-android-arm64: "npm:0.14.50"
-    esbuild-darwin-64: "npm:0.14.50"
-    esbuild-darwin-arm64: "npm:0.14.50"
-    esbuild-freebsd-64: "npm:0.14.50"
-    esbuild-freebsd-arm64: "npm:0.14.50"
-    esbuild-linux-32: "npm:0.14.50"
-    esbuild-linux-64: "npm:0.14.50"
-    esbuild-linux-arm: "npm:0.14.50"
-    esbuild-linux-arm64: "npm:0.14.50"
-    esbuild-linux-mips64le: "npm:0.14.50"
-    esbuild-linux-ppc64le: "npm:0.14.50"
-    esbuild-linux-riscv64: "npm:0.14.50"
-    esbuild-linux-s390x: "npm:0.14.50"
-    esbuild-netbsd-64: "npm:0.14.50"
-    esbuild-openbsd-64: "npm:0.14.50"
-    esbuild-sunos-64: "npm:0.14.50"
-    esbuild-windows-32: "npm:0.14.50"
-    esbuild-windows-64: "npm:0.14.50"
-    esbuild-windows-arm64: "npm:0.14.50"
+    esbuild-android-64: "npm:0.14.51"
+    esbuild-android-arm64: "npm:0.14.51"
+    esbuild-darwin-64: "npm:0.14.51"
+    esbuild-darwin-arm64: "npm:0.14.51"
+    esbuild-freebsd-64: "npm:0.14.51"
+    esbuild-freebsd-arm64: "npm:0.14.51"
+    esbuild-linux-32: "npm:0.14.51"
+    esbuild-linux-64: "npm:0.14.51"
+    esbuild-linux-arm: "npm:0.14.51"
+    esbuild-linux-arm64: "npm:0.14.51"
+    esbuild-linux-mips64le: "npm:0.14.51"
+    esbuild-linux-ppc64le: "npm:0.14.51"
+    esbuild-linux-riscv64: "npm:0.14.51"
+    esbuild-linux-s390x: "npm:0.14.51"
+    esbuild-netbsd-64: "npm:0.14.51"
+    esbuild-openbsd-64: "npm:0.14.51"
+    esbuild-sunos-64: "npm:0.14.51"
+    esbuild-windows-32: "npm:0.14.51"
+    esbuild-windows-64: "npm:0.14.51"
+    esbuild-windows-arm64: "npm:0.14.51"
   dependenciesMeta:
     esbuild-android-64:
       optional: true
@@ -3186,7 +7593,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: daef5eb1d240f82c60bdc69818da074e493376829d9b317af58599a20d408755e56e770c44983ca73aed45e013d3a78984ee90efbbff8f95174edae59be78714
+  checksum: b32a13fe3b0ba5c80524a15871d023eb27c9750c8f1f110e9f92f541a4f7dc925b2dbfcb06831c671f71461a75a6e29f06e2b5dc955855e12cca01aa6cb2ac5d
   languageName: node
   linkType: hard
 
@@ -3222,6 +7629,25 @@ __metadata:
   version: 4.0.0
   resolution: "escape-string-regexp@npm:4.0.0"
   checksum: 09f81f2e5eb8d6108ea2fe366eb3041b8bc35381c95c7b7e38f0eb64825a3967618bb0840b7a9e950457d9b4c0a6e758b69374fb7906d939a67018d6c53e8cbe
+  languageName: node
+  linkType: hard
+
+"escodegen@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "escodegen@npm:2.0.0"
+  dependencies:
+    esprima: "npm:^4.0.1"
+    estraverse: "npm:^5.2.0"
+    esutils: "npm:^2.0.2"
+    optionator: "npm:^0.8.1"
+    source-map: "npm:~0.6.1"
+  dependenciesMeta:
+    source-map:
+      optional: true
+  bin:
+    escodegen: bin/escodegen.js
+    esgenerate: bin/esgenerate.js
+  checksum: b7b02b8bc92c32b741cf13b558903c230cfd63fa37983a5c07ccac417d5ca67b266a9714180fd833947bd54221ce4fde72f8d772acc5ba1a5a1dafa25978252a
   languageName: node
   linkType: hard
 
@@ -3426,13 +7852,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^5.1.1":
+"eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
   dependencies:
     esrecurse: "npm:^4.3.0"
     estraverse: "npm:^4.1.1"
   checksum: 50c26e6abd713f6acf27498e37af26dc08d9b2781c038a32d8c44dbab59744233de58b1bd6b3a21286384ea40458962a80d8f3923c33c90369f4d0e891c69065
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "eslint-scope@npm:4.0.3"
+  dependencies:
+    esrecurse: "npm:^4.1.0"
+    estraverse: "npm:^4.1.1"
+  checksum: ea95cfc36ee6d3f7440ae4e3e5701f6cbffb2c4c7f5f8430eb3bcc8cf902ee58f1cf7ab0da11d07ccfbc7f0c4587f81c9791c69687320d72c285f4080b19622f
   languageName: node
   linkType: hard
 
@@ -3562,7 +7998,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esrecurse@npm:^4.3.0":
+"esrecurse@npm:^4.1.0, esrecurse@npm:^4.3.0":
   version: 4.3.0
   resolution: "esrecurse@npm:4.3.0"
   dependencies:
@@ -3582,6 +8018,17 @@ __metadata:
   version: 5.3.0
   resolution: "estraverse@npm:5.3.0"
   checksum: 4db420d3f0291d3c42e3700aee2986ec1ca8384224236da9441e67555c8af181fe5f883b0b312021ed475f0c138282066b0f5cb2240ee4a0c2ec5142274162d1
+  languageName: node
+  linkType: hard
+
+"estree-to-babel@npm:^3.1.0":
+  version: 3.2.1
+  resolution: "estree-to-babel@npm:3.2.1"
+  dependencies:
+    "@babel/traverse": "npm:^7.1.6"
+    "@babel/types": "npm:^7.2.0"
+    c8: "npm:^7.6.0"
+  checksum: f52b729da24c339a6e892298be485269883463acb160efcdd332e207f07ae319b70a9b0dca880433dda95de1cad69b64ae37f7f5d0274f336b7b98f29fddb4f2
   languageName: node
   linkType: hard
 
@@ -3606,6 +8053,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"etag@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "etag@npm:1.8.1"
+  checksum: 70d88dfb36416dffbb09859cb5c72a71ae9a0b3da550643a75d28d3a853c999fb30076bc33d2a1c3882988e3631093b148bacaee133e070de4798e63753b82ac
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.0.0, events@npm:^3.2.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: ef0af671f7bdc20f14274c77925c3e47a4df7991563ee1827dff577f66a9ed1a5b63d9adab8bc5949a16a1341883abdaf9df7a1841f8d5d2fc65ab4f5570b32b
+  languageName: node
+  linkType: hard
+
+"evp_bytestokey@npm:^1.0.0, evp_bytestokey@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "evp_bytestokey@npm:1.0.3"
+  dependencies:
+    md5.js: "npm:^1.3.4"
+    node-gyp: "npm:latest"
+    safe-buffer: "npm:^5.1.1"
+  checksum: 9422e1f77eb9507d587d94390108d5ab0c0e10189adca0164b88dd8a22821fd8eda74b4299b9faf40cd6578992a8e66a3db581ac7d02be3635d8048d08724670
+  languageName: node
+  linkType: hard
+
 "execa@npm:^2.0.1":
   version: 2.1.0
   resolution: "execa@npm:2.1.0"
@@ -3623,7 +8095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^5.0.0":
+"execa@npm:^5.0.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
   dependencies:
@@ -3654,6 +8126,102 @@ __metadata:
     signal-exit: "npm:^3.0.7"
     strip-final-newline: "npm:^3.0.0"
   checksum: ebe384facfb5c4e7007828a518fedb2d7704bd10e69d4584de4427d47ceadf1e9377203f4ca754c17e1a82a492b5eefad64dda65fa473bf756ab6de62124651e
+  languageName: node
+  linkType: hard
+
+"expand-brackets@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "expand-brackets@npm:2.1.4"
+  dependencies:
+    debug: "npm:^2.3.3"
+    define-property: "npm:^0.2.5"
+    extend-shallow: "npm:^2.0.1"
+    posix-character-classes: "npm:^0.1.0"
+    regex-not: "npm:^1.0.0"
+    snapdragon: "npm:^0.8.1"
+    to-regex: "npm:^3.0.1"
+  checksum: 066898f0d75a5c3375b5dfd73cd070f78bdce47fb8641cf84b9d4db0b154cd72f5597e5e288a071d2120726ce43ffbcfb291f2410a79d390d0be6b8c5d245c9b
+  languageName: node
+  linkType: hard
+
+"express@npm:^4.17.1":
+  version: 4.18.1
+  resolution: "express@npm:4.18.1"
+  dependencies:
+    accepts: "npm:~1.3.8"
+    array-flatten: "npm:1.1.1"
+    body-parser: "npm:1.20.0"
+    content-disposition: "npm:0.5.4"
+    content-type: "npm:~1.0.4"
+    cookie: "npm:0.5.0"
+    cookie-signature: "npm:1.0.6"
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    finalhandler: "npm:1.2.0"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
+    merge-descriptors: "npm:1.0.1"
+    methods: "npm:~1.1.2"
+    on-finished: "npm:2.4.1"
+    parseurl: "npm:~1.3.3"
+    path-to-regexp: "npm:0.1.7"
+    proxy-addr: "npm:~2.0.7"
+    qs: "npm:6.10.3"
+    range-parser: "npm:~1.2.1"
+    safe-buffer: "npm:5.2.1"
+    send: "npm:0.18.0"
+    serve-static: "npm:1.15.0"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:2.0.1"
+    type-is: "npm:~1.6.18"
+    utils-merge: "npm:1.0.1"
+    vary: "npm:~1.1.2"
+  checksum: 22dbd588b0c2b24786166404b9be416a4909a3e90a85f0076e7bf24a010a5d979240c79e8956c529b8cc133230a3493706a8b3648aa13cb0cd1b2c66fe08e4a8
+  languageName: node
+  linkType: hard
+
+"extend-shallow@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "extend-shallow@npm:2.0.1"
+  dependencies:
+    is-extendable: "npm:^0.1.0"
+  checksum: 55d1d466474b90d00dda6926144f41c349ca7d4d1194cdb3d37e9a662a9767cf8f62a9ff659ef0aacd30a35ee98ab801c3a411a438a5d54b275acbd4ee4fedb6
+  languageName: node
+  linkType: hard
+
+"extend-shallow@npm:^3.0.0, extend-shallow@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "extend-shallow@npm:3.0.2"
+  dependencies:
+    assign-symbols: "npm:^1.0.0"
+    is-extendable: "npm:^1.0.1"
+  checksum: 7b96b23b8effdbd4c7f35116464bfd420747d5a1f6c7055fdd5c32f1a1ff2e2f1b45464db3f6e23f3189f64b5fd99a32e245a5d0259ea28d67dfd188aa2417ab
+  languageName: node
+  linkType: hard
+
+"extend@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "extend@npm:3.0.2"
+  checksum: 312babdc3cfd8d5d003b109f02b8b639e8bdf2262f2f06acebfc3c991d8c004b73c2c10eaaaab00cfb2fb2a760845006806af10945b279d9390eed064505dfdb
+  languageName: node
+  linkType: hard
+
+"extglob@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "extglob@npm:2.0.4"
+  dependencies:
+    array-unique: "npm:^0.3.2"
+    define-property: "npm:^1.0.0"
+    expand-brackets: "npm:^2.1.4"
+    extend-shallow: "npm:^2.0.1"
+    fragment-cache: "npm:^0.2.1"
+    regex-not: "npm:^1.0.0"
+    snapdragon: "npm:^0.8.1"
+    to-regex: "npm:^3.0.1"
+  checksum: b1a97bc3c05ead651268e347c7d1a5f832eac0ddd5134cfad210f6dbd7284d987d22c0adf83f64e077901ec2cd6d584a6705886bc1077d44d1d46002ed070ccc
   languageName: node
   linkType: hard
 
@@ -3691,6 +8259,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-glob@npm:^2.2.6":
+  version: 2.2.7
+  resolution: "fast-glob@npm:2.2.7"
+  dependencies:
+    "@mrmlnc/readdir-enhanced": "npm:^2.2.1"
+    "@nodelib/fs.stat": "npm:^1.1.2"
+    glob-parent: "npm:^3.1.0"
+    is-glob: "npm:^4.0.0"
+    merge2: "npm:^1.2.3"
+    micromatch: "npm:^3.1.10"
+  checksum: f1f8a62e4f30c41e9628616f46aa7d1e75388bab04acc5c5a396359b0afb2c2db0726dcb0ef42d47a4bf15c9346dfc94a267959e1d32893b9aa34d0f11849080
+  languageName: node
+  linkType: hard
+
+"fast-json-parse@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "fast-json-parse@npm:1.0.3"
+  checksum: 05417e665911f8e28d4bd14b6cd0f95a56714dedc30546f94f7b2c2652ca812ed835fc49eabf1993aa4bee173a68986ef5252d583b97bf86801043d981b3f45a
+  languageName: node
+  linkType: hard
+
 "fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
@@ -3698,7 +8287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-levenshtein@npm:^2.0.6":
+"fast-levenshtein@npm:^2.0.6, fast-levenshtein@npm:~2.0.6":
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 7814143d0352153a7a51ebd9b21341bf1732b9599ec592a398ab5e4584b516aeb5008834ba2a46502253c221b33dad7dddc93ce3f5054acd09218cce1710c81b
@@ -3714,12 +8303,76 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fault@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "fault@npm:1.0.4"
+  dependencies:
+    format: "npm:^0.2.0"
+  checksum: 94ab3ae43eacf7ec3ab5d58e28a30779b19366ef3c66b7d7cdeeec4d5bf12841f37a2b69b4b11d679e559b2f0d1603f6db21896c219422507ab697794e55c8ad
+  languageName: node
+  linkType: hard
+
+"fetch-retry@npm:^5.0.2":
+  version: 5.0.3
+  resolution: "fetch-retry@npm:5.0.3"
+  checksum: c5984c71104db3aab018abe10fee0d9d000b2224839a15b45a7bfbb40a30136521c1984cf775b8665f8a2d1a8c3e5ca63a193a4f1c4500d10bdb2d729773444f
+  languageName: node
+  linkType: hard
+
+"figgy-pudding@npm:^3.5.1":
+  version: 3.5.2
+  resolution: "figgy-pudding@npm:3.5.2"
+  checksum: f4b8a84c3ef60a351fd7874b21e379ffbfe8be2f5da290b9db59c8a939e633e515e01ff999b57049924acfb251ea1c5c4554cc52271969e628047a576a19f056
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^6.0.1":
   version: 6.0.1
   resolution: "file-entry-cache@npm:6.0.1"
   dependencies:
     flat-cache: "npm:^3.0.4"
   checksum: cac7f7775980e696eceb922313887c03204eaea3659e0cd5b9f83ef29c7e5c613a6aa7662a3e9d0f78cf68060b093b82572e554f5464c0b2f626db32ef969cdc
+  languageName: node
+  linkType: hard
+
+"file-loader@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "file-loader@npm:6.2.0"
+  dependencies:
+    loader-utils: "npm:^2.0.0"
+    schema-utils: "npm:^3.0.0"
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 437c5fd08f2ec95c017510d8b14a490c1af4b01201efe228eaace5313c4eb61f3510137adf0945cf1fc64dec5f4bf1359d0bd6c67d51778801f6574f336cc08f
+  languageName: node
+  linkType: hard
+
+"file-system-cache@npm:^1.0.5":
+  version: 1.1.0
+  resolution: "file-system-cache@npm:1.1.0"
+  dependencies:
+    fs-extra: "npm:^10.1.0"
+    ramda: "npm:^0.28.0"
+  checksum: 600d15c10f33d760764e139312cf42da9590b33d3d7cd9eb92775ed636b96b3757cb01a4614352fe965e20dffddef00cead29e57dcd911a15fc2681382300251
+  languageName: node
+  linkType: hard
+
+"file-uri-to-path@npm:1.0.0":
+  version: 1.0.0
+  resolution: "file-uri-to-path@npm:1.0.0"
+  checksum: 38ecb8791c47805252036ab44cf946719e55b879548d2fe7305cc02a6b492b6ff37e0b92db42d9ba3fcc95a82d3fd5ef99b03b9289019ca4c0a067126467075b
+  languageName: node
+  linkType: hard
+
+"fill-range@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "fill-range@npm:4.0.0"
+  dependencies:
+    extend-shallow: "npm:^2.0.1"
+    is-number: "npm:^3.0.0"
+    repeat-string: "npm:^1.6.1"
+    to-regex-range: "npm:^2.1.0"
+  checksum: fcaf0e34e6c058aa4a0f8334ff56db4c1a3168d97e21676092bccc7109f6f1fb39d604f19247522b7d2daee0b03ac335c4aa1e4e97ee2b07bdd0c6105767f8c9
   languageName: node
   linkType: hard
 
@@ -3732,22 +8385,63 @@ __metadata:
   languageName: node
   linkType: hard
 
-"finalhandler@npm:1.1.2":
-  version: 1.1.2
-  resolution: "finalhandler@npm:1.1.2"
+"finalhandler@npm:1.2.0":
+  version: 1.2.0
+  resolution: "finalhandler@npm:1.2.0"
   dependencies:
     debug: "npm:2.6.9"
     encodeurl: "npm:~1.0.2"
     escape-html: "npm:~1.0.3"
-    on-finished: "npm:~2.3.0"
+    on-finished: "npm:2.4.1"
     parseurl: "npm:~1.3.3"
-    statuses: "npm:~1.5.0"
+    statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
-  checksum: f485540ba47bc84d4139e8418faa0aa9c146c4de25a275defb827c6887cdd3193352486e39836c59a5fca747baf409c48c02648173a17849c44bba4f610d2995
+  checksum: 31ca595367c936c6614f67bd94c7e64a31ad9b8bd52751811b4f9deb666928d8da578a230baacf7760845126ef35330382a2e935f0757d22312ba942056dc1c1
   languageName: node
   linkType: hard
 
-"find-up@npm:^4.1.0":
+"find-cache-dir@npm:^2.0.0, find-cache-dir@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "find-cache-dir@npm:2.1.0"
+  dependencies:
+    commondir: "npm:^1.0.1"
+    make-dir: "npm:^2.0.0"
+    pkg-dir: "npm:^3.0.0"
+  checksum: b93279ab43e314cd6d779b1524982a5101da35a822b54c1bd664f7f1fac4fb4a09626e10604e1fb672700cba8addf134839de5a2673a55079e25bf6527fac31a
+  languageName: node
+  linkType: hard
+
+"find-cache-dir@npm:^3.3.1":
+  version: 3.3.2
+  resolution: "find-cache-dir@npm:3.3.2"
+  dependencies:
+    commondir: "npm:^1.0.1"
+    make-dir: "npm:^3.0.2"
+    pkg-dir: "npm:^4.1.0"
+  checksum: 39e977251433aacc1d60b40f6d9bdfa7e5290aa181f4828d654f109a57738326bf39cd88a597a77f64ce5fc7af394a5fe6993c7343b285bc82e12eb6dfc96d04
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "find-up@npm:1.1.2"
+  dependencies:
+    path-exists: "npm:^2.0.0"
+    pinkie-promise: "npm:^2.0.0"
+  checksum: 53e37bd2bee613512b65fd6aea5c428a800732a76ff00df6a87cbe4a783dd680a4d32eaa6709802caf7b0ab420e7a8fbd0787ba2d218c1c9fe6a3858f218883f
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "find-up@npm:3.0.0"
+  dependencies:
+    locate-path: "npm:^3.0.0"
+  checksum: edbd2334fcfb1391af9f246bbf6aa2e7187bdc807150ba7e39dca2c0a7a07560ea49dd7a86e266465de0934958da6ad0f9526d46af1e952f1d2fb858d76bc598
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^4.0.0, find-up@npm:^4.1.0":
   version: 4.1.0
   resolution: "find-up@npm:4.1.0"
   dependencies:
@@ -3784,6 +8478,79 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flush-write-stream@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "flush-write-stream@npm:1.1.1"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^2.3.6"
+  checksum: cb7d1a27d86fa2e8f73c9b87ec509127a168462ed342c75f62063ee1e9d84d415dc71c7daac05d5885cc7449d0a43892d825445b7358772c2d8b88690da378c0
+  languageName: node
+  linkType: hard
+
+"for-in@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "for-in@npm:1.0.2"
+  checksum: 7e1328a767701fcd94b4244d196f249b35d252ad04b542d2023d1ba5905e81e9134317c9d6b6c9a3c33bd47fe191b31f18c602c4fc9fafd1ee02c8d7c4290e67
+  languageName: node
+  linkType: hard
+
+"foreground-child@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "foreground-child@npm:2.0.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 8187629907a23d158cc4be6bf6205e51907f00c2d7068e425caebb21cda84cfe07f2e4b4b2929a591f0e7f1694e0b3980b3ba5298723ff9eca828ab483098051
+  languageName: node
+  linkType: hard
+
+"fork-ts-checker-webpack-plugin@npm:^4.1.6":
+  version: 4.1.6
+  resolution: "fork-ts-checker-webpack-plugin@npm:4.1.6"
+  dependencies:
+    "@babel/code-frame": "npm:^7.5.5"
+    chalk: "npm:^2.4.1"
+    micromatch: "npm:^3.1.10"
+    minimatch: "npm:^3.0.4"
+    semver: "npm:^5.6.0"
+    tapable: "npm:^1.0.0"
+    worker-rpc: "npm:^0.1.0"
+  checksum: 9c239c593ed94bbd6664c290f333ab2e13c6e7bf5bacf1a40c0327b8831f1a2bbc651881981a717c68d0bdd47d9ef4420db6d544afc4be3c1e37e644a4e27cf5
+  languageName: node
+  linkType: hard
+
+"fork-ts-checker-webpack-plugin@npm:^6.0.4":
+  version: 6.5.2
+  resolution: "fork-ts-checker-webpack-plugin@npm:6.5.2"
+  dependencies:
+    "@babel/code-frame": "npm:^7.8.3"
+    "@types/json-schema": "npm:^7.0.5"
+    chalk: "npm:^4.1.0"
+    chokidar: "npm:^3.4.2"
+    cosmiconfig: "npm:^6.0.0"
+    deepmerge: "npm:^4.2.2"
+    fs-extra: "npm:^9.0.0"
+    glob: "npm:^7.1.6"
+    memfs: "npm:^3.1.2"
+    minimatch: "npm:^3.0.4"
+    schema-utils: "npm:2.7.0"
+    semver: "npm:^7.3.2"
+    tapable: "npm:^1.0.0"
+  peerDependencies:
+    eslint: ">= 6"
+    typescript: ">= 2.7"
+    vue-template-compiler: "*"
+    webpack: ">= 4"
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+    vue-template-compiler:
+      optional: true
+  checksum: 36014c4d4644e5e96d09c5c080b8b8eef081f3efec4ae2bf5cc3305f3dabfc65a10630698e71a0b8273e931cc2480c50188a913e03ab882b0b7698db8ec8e296
+  languageName: node
+  linkType: hard
+
 "form-data@npm:^3.0.0":
   version: 3.0.1
   resolution: "form-data@npm:3.0.1"
@@ -3792,6 +8559,46 @@ __metadata:
     combined-stream: "npm:^1.0.8"
     mime-types: "npm:^2.1.12"
   checksum: 4ca2af6f04d3e3914b6ed8e5ea256da66c883bc2ae64651929f5eb842a47b6461fa51cd19c2a1d5ede09f5117593f2622814c34f8e0ac4869b91a4815c401753
+  languageName: node
+  linkType: hard
+
+"format@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "format@npm:0.2.2"
+  checksum: 015887086e10ccaa835c2fd1cdb42cded5df53d0daf2a2f43c15eda7f50a29dc983b87fa501bf62a5f4fb1655a719b80d3fa4105f31677ecd37510380dbbab37
+  languageName: node
+  linkType: hard
+
+"forwarded@npm:0.2.0":
+  version: 0.2.0
+  resolution: "forwarded@npm:0.2.0"
+  checksum: d1d18e065b310fb44e3190497119b810db59da95a8ac0ba186e94385484c72e189e9a5da404a209886fdcfaacc1efcb066e7d90c4281dfd7e3ce3ccd18a8dd32
+  languageName: node
+  linkType: hard
+
+"fragment-cache@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "fragment-cache@npm:0.2.1"
+  dependencies:
+    map-cache: "npm:^0.2.2"
+  checksum: 2a3a27cb1381b8ab24227bd3f5bc3df610c8628585945aa549abbbf0faff8dbf919986b3df6325e4a2dd7835466d0d271587d27f660ad007d273f9613f8b36a5
+  languageName: node
+  linkType: hard
+
+"fresh@npm:0.5.2":
+  version: 0.5.2
+  resolution: "fresh@npm:0.5.2"
+  checksum: 57c25f8cdc1c8db81fc3477b8073627614c5132ae7070c8e920ff35afbddb32f98d74ab6828d92f1e1c52583b2f8ea16ac7991406ffe2bb4ec752b1aaa94350e
+  languageName: node
+  linkType: hard
+
+"from2@npm:^2.1.0":
+  version: 2.3.0
+  resolution: "from2@npm:2.3.0"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    readable-stream: "npm:^2.0.0"
+  checksum: 6417f57ccc4da4cffc06909985d485181580ed129d916b009edb035554a258a19ff1345b0b9735b82d018589d7b959beb43007f562986df59f66f7ab1c02ed46
   languageName: node
   linkType: hard
 
@@ -3806,12 +8613,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^9.0.0, fs-extra@npm:^9.0.1":
+  version: 9.1.0
+  resolution: "fs-extra@npm:9.1.0"
+  dependencies:
+    at-least-node: "npm:^1.0.0"
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: fc8ff3111ca42a4a3118e63247b1ebe4fbe4abc6daed2d51414699efb5661a2b9aeeb1b9283cb63544011a50b8f59c315e53b06d9c1b38a7786be99f8e59dabb
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^2.0.0, fs-minipass@npm:^2.1.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
   dependencies:
     minipass: "npm:^3.0.0"
   checksum: 56d19f9a034cbef50b7fe846a71ab1a6a7ee7906205f9f18b7c9696e1f6d83c4d708a0196c65536f34e569205664840dd4f97f1286a26148a4c5bf74a67fe8db
+  languageName: node
+  linkType: hard
+
+"fs-monkey@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "fs-monkey@npm:1.0.3"
+  checksum: fc4c994978d617d5f4dca22ecd385e2262ea724e5b74a2b2bbd86652c07051d02e51128126dd4c70a25a8111505c8121de0e221eaf29410a11b217edf4c3d26d
+  languageName: node
+  linkType: hard
+
+"fs-write-stream-atomic@npm:^1.0.8":
+  version: 1.0.10
+  resolution: "fs-write-stream-atomic@npm:1.0.10"
+  dependencies:
+    graceful-fs: "npm:^4.1.2"
+    iferr: "npm:^0.1.5"
+    imurmurhash: "npm:^0.1.4"
+    readable-stream: "npm:1 || 2"
+  checksum: b2120a606700734377292ee2367695a38454b849a65df7ae48b3c78b459f313cc22fc71a2d8099e427580dae33489c2f0e32a212e8045aa2e5edd48a61f1bd6e
   languageName: node
   linkType: hard
 
@@ -3822,12 +8660,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:^1.2.7":
+  version: 1.2.13
+  resolution: "fsevents@npm:1.2.13"
+  dependencies:
+    bindings: "npm:^1.5.0"
+    nan: "npm:^2.12.1"
+  checksum: 169ab95170cf57c2fcb90eb459e0c51bf3a5aaa902cd5a91721d4d41a665bd35cc3f27e588883585ddd536bca7668f466bb6b8227f57aa108b82d36ed6f43e63
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
     node-gyp: "npm:latest"
   checksum: c85eed7a3e0bbe6908f9feae8a823ee63a796ea2b32e20616ee33f0dda9417976f5a087a8cd2ccf228aae1c5b8b6125c9800f05dd69aaf016c34352a0567dcfb
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A^1.2.7#optional!builtin<compat/fsevents>":
+  version: 1.2.13
+  resolution: "fsevents@patch:fsevents@npm%3A1.2.13#optional!builtin<compat/fsevents>::version=1.2.13&hash=18f3a7"
+  dependencies:
+    bindings: "npm:^1.5.0"
+    nan: "npm:^2.12.1"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -3848,7 +8707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"function.prototype.name@npm:^1.1.5":
+"function.prototype.name@npm:^1.1.0, function.prototype.name@npm:^1.1.5":
   version: 1.1.5
   resolution: "function.prototype.name@npm:1.1.5"
   dependencies:
@@ -3871,6 +8730,23 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: 2b58e5d607d7338c29e5ff8c285ddf09d79857b6d0ef9f781ee2e80cf666726d6909b5ab635e13d49ded9dcfd3c7abc01a22a52089bf23833848a6bfb6e8dac1
+  languageName: node
+  linkType: hard
+
+"gauge@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "gauge@npm:3.0.2"
+  dependencies:
+    aproba: "npm:^1.0.3 || ^2.0.0"
+    color-support: "npm:^1.1.2"
+    console-control-strings: "npm:^1.0.0"
+    has-unicode: "npm:^2.0.1"
+    object-assign: "npm:^4.1.1"
+    signal-exit: "npm:^3.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+    wide-align: "npm:^1.1.2"
+  checksum: 96562a18ce38a11892c75ccea5f82b06cc4a8a2a03b24e8a3dfb5497cc71b75f8aabd70cbcb3b4660e699301690cd8a58c124c8327fc2da9a2507caf54f45ceb
   languageName: node
   linkType: hard
 
@@ -3897,7 +8773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gensync@npm:^1.0.0-beta.2":
+"gensync@npm:^1.0.0-beta.1, gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
   checksum: c3e28898b5eb6cf92ce2f3bd1230f87bb642803aa743cbce53af55b50283a5283922a8717208edf1912ec1d944f1a4b262e9abfdb9ff9695e61f2939e56c89d8
@@ -3929,10 +8805,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-port@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "get-port@npm:5.1.1"
-  checksum: 93afec66950abbe4a7a004543c5d94dbf22c2649598482c8064acfceae7663cae62c7aaef448f7ec6744b37286e89eed2bada01726a6ca4e09e3809d92e4fccc
+"get-stdin@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "get-stdin@npm:4.0.1"
+  checksum: 26f5c78551321c384796e6280ff06c9be861695d68b7923ae72ad9d36e227e6b0c5654907a06912dc1e9079c19a8e82c54c7a64350a358d4bc4211fe202ba588
   languageName: node
   linkType: hard
 
@@ -3969,6 +8845,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-value@npm:^2.0.3, get-value@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "get-value@npm:2.0.6"
+  checksum: 76d53ea787af176684a9b29d81ac2d1ede3de60ebabb20e9be91c55e619aeca9928c4b754dd40e12f613d42740357bda7048beb42df2827be663b5181192d687
+  languageName: node
+  linkType: hard
+
 "git-raw-commits@npm:^2.0.0":
   version: 2.0.11
   resolution: "git-raw-commits@npm:2.0.11"
@@ -3984,7 +8867,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.2":
+"glob-parent@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "glob-parent@npm:3.1.0"
+  dependencies:
+    is-glob: "npm:^3.1.0"
+    path-dirname: "npm:^1.0.0"
+  checksum: ac69a90527002c0ccf65b37de4a9107ff9443b51524c90c28a9139d74e5cd82e12a40c978b6f8ee66788915ebc48e083e1a79e9f06672caa93127f6b07d4879e
+  languageName: node
+  linkType: hard
+
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -4002,6 +8895,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob-promise@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "glob-promise@npm:3.4.0"
+  dependencies:
+    "@types/glob": "npm:*"
+  peerDependencies:
+    glob: "*"
+  checksum: 39f2fa98380c6143ce996a8787cc918bc74b444901a886c4244370c42f297144260dabf70f576c0531e7de8ff8a966af2f24d5cb3011384d787de572a9fafbd6
+  languageName: node
+  linkType: hard
+
 "glob-regex@npm:^0.3.0":
   version: 0.3.2
   resolution: "glob-regex@npm:0.3.2"
@@ -4009,7 +8913,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.1.7":
+"glob-to-regexp@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "glob-to-regexp@npm:0.3.0"
+  checksum: ec0d1a74819df29b9a587d38cceefe14b25a6220dbd3787ca11835696fa539323c7011d9062a6dadcde937ab703a1f1910bfce083718948c33fff017fa427dbe
+  languageName: node
+  linkType: hard
+
+"glob-to-regexp@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "glob-to-regexp@npm:0.4.1"
+  checksum: 8d5332e7b023069e25af4de7833bc391144926546a469c187848b4509106ffdb9815c7e1a0fae80398d682fdc4b6fcb6b91fa42b5e966018d21ff442751d2d3b
+  languageName: node
+  linkType: hard
+
+"glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -4045,6 +8963,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"global@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "global@npm:4.4.0"
+  dependencies:
+    min-document: "npm:^2.19.0"
+    process: "npm:^0.11.10"
+  checksum: 7c4f4aa52123864d5a9327e0a8be0890487c95015c06103c108b314f35464aa5afaf9b32ea3c31f0f7efcac528283deb4f7a82dccd7081c4ca3e0b70916dbfd9
+  languageName: node
+  linkType: hard
+
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -4061,7 +8989,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.3, globby@npm:^11.1.0":
+"globalthis@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "globalthis@npm:1.0.3"
+  dependencies:
+    define-properties: "npm:^1.1.3"
+  checksum: 712d9e130f2c47067e6590cb1eee418df1106f53ffeddaadb4c8b0793ac0f46039e5f71008c44089523aa2b58d270bb2c4e5721795ddad114bc23d9eb63ec6d5
+  languageName: node
+  linkType: hard
+
+"globby@npm:^11.0.2, globby@npm:^11.0.3, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -4089,6 +9026,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globby@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "globby@npm:9.2.0"
+  dependencies:
+    "@types/glob": "npm:^7.1.1"
+    array-union: "npm:^1.0.2"
+    dir-glob: "npm:^2.2.2"
+    fast-glob: "npm:^2.2.6"
+    glob: "npm:^7.1.3"
+    ignore: "npm:^4.0.3"
+    pify: "npm:^4.0.1"
+    slash: "npm:^2.0.0"
+  checksum: 92a56ca20cdd1d55b4344e15edec0845d7227e35a99c2ec9710bb6e62004f293cfcd600960ac3195ff8d122dabcf49a670a909540bf8a487aa71186de2be08c9
+  languageName: node
+  linkType: hard
+
 "globrex@npm:^0.1.2":
   version: 0.1.2
   resolution: "globrex@npm:0.1.2"
@@ -4096,7 +9049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 6b5f9b5aeaee0459b9c37bdbf9624f788703ce291d6bf2d7751f5003942e853f232ca613aec818d1ff7622379bc8b434c635bfda99db93e0b9b8da80ec3d844d
@@ -4114,6 +9067,24 @@ __metadata:
   version: 1.3.0
   resolution: "growly@npm:1.3.0"
   checksum: 55f8f1431189a7fbdbba91468993bd1859dc60492491b787cbd7766e009c8aab93661a609f4975196040c3089b33f02bb46e4b9bbeb09dff125a6747b9743129
+  languageName: node
+  linkType: hard
+
+"handlebars@npm:^4.7.7":
+  version: 4.7.7
+  resolution: "handlebars@npm:4.7.7"
+  dependencies:
+    minimist: "npm:^1.2.5"
+    neo-async: "npm:^2.6.0"
+    source-map: "npm:^0.6.1"
+    uglify-js: "npm:^3.1.4"
+    wordwrap: "npm:^1.0.0"
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 132aa454ca6daac6e4dc9bc267fb182fde3876ae994364ce770e178d85112e51fee9240e1ae4c723b89ca84e193e19385122ccccd47aae2ef07e5bdb3fa6d959
   languageName: node
   linkType: hard
 
@@ -4142,6 +9113,15 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 71f182c441adda71ea3014dec578691a9d74356dd57c238fb2fc88247a94ca10892fe307cda0eb608b91f982d7da34aa2e46f763c4449351dedac26a0493e591
+  languageName: node
+  linkType: hard
+
+"has-glob@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "has-glob@npm:1.0.0"
+  dependencies:
+    is-glob: "npm:^3.0.0"
+  checksum: 566f9165c2958553bbd1858ab9b722494179cfca472907464c8454d13e5871706712ed9d7cbe8122517534da33643f20642519f5e993fa1b17cde6b66cc41bc4
   languageName: node
   linkType: hard
 
@@ -4184,12 +9164,188 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-value@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "has-value@npm:0.3.1"
+  dependencies:
+    get-value: "npm:^2.0.3"
+    has-values: "npm:^0.1.4"
+    isobject: "npm:^2.0.0"
+  checksum: 878ef6cb55dc0dce4b1000172c1b159a6c326275401c3abb61c135dd66d1d49fc14504b01e190e8fe5491a9c124dfd421c2f06677742bad9297c0aafaae83f69
+  languageName: node
+  linkType: hard
+
+"has-value@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "has-value@npm:1.0.0"
+  dependencies:
+    get-value: "npm:^2.0.6"
+    has-values: "npm:^1.0.0"
+    isobject: "npm:^3.0.0"
+  checksum: 318450fdded9b0cdd08a166551970b04e64d750be750dd69f17b9f1a827c3110da4a97c2306f9fb3ec68a04440f2d1add2fe79238fa9ed2b1d07bc30cb0d4e9d
+  languageName: node
+  linkType: hard
+
+"has-values@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "has-values@npm:0.1.4"
+  checksum: 63a02eb81992795e05218cd2757844cdf231aed3d5c93805aa2f04caf1138703762d486ce79532b7d84f401ecba96afd2fdf748f9b89d9b68c11ae52f944e2b1
+  languageName: node
+  linkType: hard
+
+"has-values@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "has-values@npm:1.0.0"
+  dependencies:
+    is-number: "npm:^3.0.0"
+    kind-of: "npm:^4.0.0"
+  checksum: 2f79de8562890b08d5d066d8a283f9392bacc2a75a005b12e1bc57df8c04cd5bce419eef9dff4a82398f00368460bba863d4d42bd30976ddca2cf00aacc9e020
+  languageName: node
+  linkType: hard
+
 "has@npm:^1.0.3":
   version: 1.0.3
   resolution: "has@npm:1.0.3"
   dependencies:
     function-bind: "npm:^1.1.1"
   checksum: 3e8c4d87ccd9c160d61a5db829b5fb647acac79e482476c857d5d1dc580517c6a77cf84337808f28361f6263008ce1ce5aff44407bd9241af93c623ef8d8d4f1
+  languageName: node
+  linkType: hard
+
+"hash-base@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "hash-base@npm:3.1.0"
+  dependencies:
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^3.6.0"
+    safe-buffer: "npm:^5.2.0"
+  checksum: 31109e871639384b20dcd804d4a82e20008b01d1c96eaf285f70fda42df650970c008da1d3c5d898211bdc84d792c2a6f8075ce931b2fc305defcbb7b4fa27f3
+  languageName: node
+  linkType: hard
+
+"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
+  version: 1.1.7
+  resolution: "hash.js@npm:1.1.7"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    minimalistic-assert: "npm:^1.0.1"
+  checksum: e4266370d194fd31ed7bb51f5a943cf4e3b361321ea19a0dfcaab2e21400c3e581d8dec897364ed4530845c2c1b58d44dd6a9b3682cfd5ec02d0ce7bc802f1db
+  languageName: node
+  linkType: hard
+
+"hast-to-hyperscript@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "hast-to-hyperscript@npm:9.0.1"
+  dependencies:
+    "@types/unist": "npm:^2.0.3"
+    comma-separated-tokens: "npm:^1.0.0"
+    property-information: "npm:^5.3.0"
+    space-separated-tokens: "npm:^1.0.0"
+    style-to-object: "npm:^0.3.0"
+    unist-util-is: "npm:^4.0.0"
+    web-namespaces: "npm:^1.0.0"
+  checksum: 9bc4b89b2d24206ca7c0c67b8801d67d89689f03741411c91c76b00d47a7128cc00b8bdbdc2f3b2029ef1002b7d64f54649e13774f0c82175f0a29a9b145908a
+  languageName: node
+  linkType: hard
+
+"hast-util-from-parse5@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "hast-util-from-parse5@npm:6.0.1"
+  dependencies:
+    "@types/parse5": "npm:^5.0.0"
+    hastscript: "npm:^6.0.0"
+    property-information: "npm:^5.0.0"
+    vfile: "npm:^4.0.0"
+    vfile-location: "npm:^3.2.0"
+    web-namespaces: "npm:^1.0.0"
+  checksum: 4086e57aa3a58111fdf429db3e4f6db2e8c2c665205dd5161e7fa9353d917b22bbd51b629a7319a25ce6fe1877c1ae0bf129782d9b1328bda86bc6b0f2d48bc8
+  languageName: node
+  linkType: hard
+
+"hast-util-parse-selector@npm:^2.0.0":
+  version: 2.2.5
+  resolution: "hast-util-parse-selector@npm:2.2.5"
+  checksum: f5aaf62557ae041d3dd620efc30c512a291943aba1cec7220a36a177e202d054829ee941f50e9e9052b51299687951ad224d347b1e05c42547375b2bcb0af4e3
+  languageName: node
+  linkType: hard
+
+"hast-util-raw@npm:6.0.1":
+  version: 6.0.1
+  resolution: "hast-util-raw@npm:6.0.1"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    hast-util-from-parse5: "npm:^6.0.0"
+    hast-util-to-parse5: "npm:^6.0.0"
+    html-void-elements: "npm:^1.0.0"
+    parse5: "npm:^6.0.0"
+    unist-util-position: "npm:^3.0.0"
+    vfile: "npm:^4.0.0"
+    web-namespaces: "npm:^1.0.0"
+    xtend: "npm:^4.0.0"
+    zwitch: "npm:^1.0.0"
+  checksum: 9f40ca471b2f495c779a786614d54b4291a2c9f60871c7582757c0e1e0e63598a58c7febbd001081f4bd9c3647aa1c4488f3393e0da6487aefc39f6230eb0cc4
+  languageName: node
+  linkType: hard
+
+"hast-util-to-parse5@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "hast-util-to-parse5@npm:6.0.0"
+  dependencies:
+    hast-to-hyperscript: "npm:^9.0.0"
+    property-information: "npm:^5.0.0"
+    web-namespaces: "npm:^1.0.0"
+    xtend: "npm:^4.0.0"
+    zwitch: "npm:^1.0.0"
+  checksum: 3f2e87a5e64eeb102bab39b884278d0dc0dedda9d329a884daa73461c1f20fe0317eae21c9718daeee872aab176d487b384912bf1568a4312ca1669471ca0cca
+  languageName: node
+  linkType: hard
+
+"hastscript@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "hastscript@npm:6.0.0"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    comma-separated-tokens: "npm:^1.0.0"
+    hast-util-parse-selector: "npm:^2.0.0"
+    property-information: "npm:^5.0.0"
+    space-separated-tokens: "npm:^1.0.0"
+  checksum: 94981d36354510a721fcab92165a88eaa3a16837e3360ae85c892e8f1a72dc3b82ced0e3f4be79d0176e2bc54eb990034a7463db990da3da8ed18f32641feaae
+  languageName: node
+  linkType: hard
+
+"he@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "he@npm:1.2.0"
+  bin:
+    he: bin/he
+  checksum: 624468c0a4a0086a722b756a53eddf35a141a16ab41ab965028d0280010753cd2e12a1181e2e638ffd4c9d5131949e198fd8e509b61645b02e8e36a7bdeadc97
+  languageName: node
+  linkType: hard
+
+"highlight.js@npm:^10.4.1, highlight.js@npm:~10.7.0":
+  version: 10.7.3
+  resolution: "highlight.js@npm:10.7.3"
+  checksum: 4ea636717f9cde3bcc98659e620983fb287f91933b7be5713ce6e0c0f22221ded923dda02128eb9611f69e226b8aaac961090a74d752f66a89cf7d954e015f03
+  languageName: node
+  linkType: hard
+
+"hmac-drbg@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "hmac-drbg@npm:1.0.1"
+  dependencies:
+    hash.js: "npm:^1.0.3"
+    minimalistic-assert: "npm:^1.0.0"
+    minimalistic-crypto-utils: "npm:^1.0.1"
+  checksum: 4e88d58ffc03e027990bbc31c0aa7b90dc4d2b3642ac3a8f3b71e3c43eb03416179ac601f36417312f0375cc382a9e39d80ade1ae239aff188701162bc84226d
+  languageName: node
+  linkType: hard
+
+"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.3.0":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: "npm:^16.7.0"
+  checksum: fb03b1e426696928dfbae467baf12bdf123fccb051d92fd677c4f290d43dea52ebe7a555c3afc6f3babc657961df2ab50a70bb13739be72904f893598b98b8d7
   languageName: node
   linkType: hard
 
@@ -4216,10 +9372,99 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-entities@npm:^2.1.0":
+  version: 2.3.3
+  resolution: "html-entities@npm:2.3.3"
+  checksum: cad32c60fce7137f0b3aefc30ba3b0438d6881299230f5a40aec720829ff00d2277ac5f9be4701615d3484c5cfd8260681c6b8f7947021bda294650f38c65e9f
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: f13dc2e2ea3e037740597d93b96516baf728392777f4696fbe41b82522593d59a467884751a23cdbb440aa752a5f767c57b958c9dd02f6861eaf45b9b46a1c38
+  languageName: node
+  linkType: hard
+
+"html-minifier-terser@npm:^5.0.1":
+  version: 5.1.1
+  resolution: "html-minifier-terser@npm:5.1.1"
+  dependencies:
+    camel-case: "npm:^4.1.1"
+    clean-css: "npm:^4.2.3"
+    commander: "npm:^4.1.1"
+    he: "npm:^1.2.0"
+    param-case: "npm:^3.0.3"
+    relateurl: "npm:^0.2.7"
+    terser: "npm:^4.6.3"
+  bin:
+    html-minifier-terser: cli.js
+  checksum: 673c20cb8a65327db5ae77a0ba3ef4507f4b27487337dcde6cb8d271a27d05cd2f44df0ab419e438029e05a31ffbcb0bdd5d054800fea110c0321da9fd0d1e51
+  languageName: node
+  linkType: hard
+
+"html-tags@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "html-tags@npm:3.2.0"
+  checksum: 5829fc4936121f4b6ae29a7ee8555bdc3376dbdb37e0e9186c0346e225e8d1f67aaa6d3aa4847e0b191cba4f2aba591b16a8e416dc282b198bc1da08ac319fe0
+  languageName: node
+  linkType: hard
+
+"html-void-elements@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "html-void-elements@npm:1.0.5"
+  checksum: 80a4df437b276e24b201a8b1c20fd634fa38b9861df5b92842f505a1bb7ff9002b5c0e2044da9d3695c44c7938a7e0a753744c24fa574411e338a682340bffc1
+  languageName: node
+  linkType: hard
+
+"html-webpack-plugin@npm:^4.0.0":
+  version: 4.5.2
+  resolution: "html-webpack-plugin@npm:4.5.2"
+  dependencies:
+    "@types/html-minifier-terser": "npm:^5.0.0"
+    "@types/tapable": "npm:^1.0.5"
+    "@types/webpack": "npm:^4.41.8"
+    html-minifier-terser: "npm:^5.0.1"
+    loader-utils: "npm:^1.2.3"
+    lodash: "npm:^4.17.20"
+    pretty-error: "npm:^2.1.1"
+    tapable: "npm:^1.1.3"
+    util.promisify: "npm:1.0.0"
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 798c86137edd0032139cf6939138e17efc5a45afd592874139532b0bb979e2fc17d366ed67bab2e50698af87c15cb4ced95a8cf07936bad77bda4597f6791616
+  languageName: node
+  linkType: hard
+
+"htmlparser2@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "htmlparser2@npm:6.1.0"
+  dependencies:
+    domelementtype: "npm:^2.0.1"
+    domhandler: "npm:^4.0.0"
+    domutils: "npm:^2.5.2"
+    entities: "npm:^2.0.0"
+  checksum: 6b8a9603d26a83f873b312380cae3291f2dc1ca202288959d336a58ade7c86142b072c182b2c13cd7715cb82e9722afa0b654d95dbd88185f2d4e6b6a4829efe
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.0":
   version: 4.1.0
   resolution: "http-cache-semantics@npm:4.1.0"
   checksum: ccfe23dd2729bc564ab419330e0c4646a1247e8dd728a4a6b3ab427b5243d2e0afea0c6fe690ff9ead43d02bd84cc5240e996543c4c87866f272e26e40540acd
+  languageName: node
+  linkType: hard
+
+"http-errors@npm:2.0.0":
+  version: 2.0.0
+  resolution: "http-errors@npm:2.0.0"
+  dependencies:
+    depd: "npm:2.0.0"
+    inherits: "npm:2.0.4"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:2.0.1"
+    toidentifier: "npm:1.0.1"
+  checksum: 4ca64437169c64e448700bfc07ebaf5555bc0bb5c0880ab171a20312580af586f0c9f1bd5e9047336c84b4a31ade801ca7fe8c1c7e1d654f4ea9d5dee71dbb3c
   languageName: node
   linkType: hard
 
@@ -4231,6 +9476,13 @@ __metadata:
     agent-base: "npm:6"
     debug: "npm:4"
   checksum: b59a9b4bdd7c1d3450956a2974cb7b685517c758853a873064a536f5a831879ac92a28c717f69eb60ff3c924b262cb5aaf80cf62f5c2c24d1129d2b8dadf1e7c
+  languageName: node
+  linkType: hard
+
+"https-browserify@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "https-browserify@npm:1.0.0"
+  checksum: 9501b9bfead16b24b6d24ab2d88906435bf2d3176366944a2d5dace23e3e905d5f90f431e07e0bebe49d9dbb4889708cf53018b3589328cf682c87ad45fc4c6a
   languageName: node
   linkType: hard
 
@@ -4276,12 +9528,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 6cc23a171d6fe7c49ab89956a5f151dfc4db34b48b61cebe887051e35dbb9bebb25bf5e410e8c79efadfd8ed602a0f79f7d7814f77365841e0596c3136408eaf
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 14633c984e398011b4cce3d453e6566e4cc1b58f257e6fc48ae39c25a158b926e6cd7ee6023cd84aff12952a7581bd10bd4e7954af802dd5678e83b4cb8fdbba
+  languageName: node
+  linkType: hard
+
+"icss-utils@npm:^4.0.0, icss-utils@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "icss-utils@npm:4.1.1"
+  dependencies:
+    postcss: "npm:^7.0.14"
+  checksum: 6edb36c918d04eb04d7ac65f8d742c62a758645da03e8b9335626cfe87450a6fe8bdafb60f96df459e74c026a833084bf174814026d0eed25ed73e0ffa0599c5
+  languageName: node
+  linkType: hard
+
+"ieee754@npm:^1.1.4":
+  version: 1.2.1
+  resolution: "ieee754@npm:1.2.1"
+  checksum: b39fbc42879544ab1989f8ff439a3f3545d7c244a07f24607c4223291ba82ce95964a7b7fde24010ba899937046c4dfe01398c8f8bbddb53f9e562c29f18f615
+  languageName: node
+  linkType: hard
+
+"iferr@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "iferr@npm:0.1.5"
+  checksum: 068f314cebe13d90287f1dbf103f44918d4780cd70806fcfa8a6b9c7e89751ed4486437268fd6f8a6493ef3abdef05f9376887dfd776a6745130d68423160a62
   languageName: node
   linkType: hard
 
@@ -4292,6 +9576,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore@npm:^4.0.3":
+  version: 4.0.6
+  resolution: "ignore@npm:4.0.6"
+  checksum: 5eda966035508d977e48d34b301564ada1047e26575f218e6a47cb2b615215abdb863d5995faf00272a013080600dffb0ae3eec91fd4f1a9915500381fbf54ce
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.1.1, ignore@npm:^5.2.0":
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
@@ -4299,7 +9590,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
+"import-fresh@npm:^3.0.0, import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
   dependencies:
@@ -4313,6 +9604,15 @@ __metadata:
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
   checksum: 6e2473e6083063b9f5f21a9586794b3af5b3f87995bcf60cb64f3824a7323c2ae41b4eaf3d7446e20fb66b5f3410094246aa3c52db7585270c8b10f762b8ffa1
+  languageName: node
+  linkType: hard
+
+"indent-string@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "indent-string@npm:2.1.0"
+  dependencies:
+    repeating: "npm:^2.0.0"
+  checksum: 5fb1e3a74f1f1d781517a8ea8dfd6d10fca52f647f83e43f395450e9d662b9d643d0ade6df2cbab8561ce683b828546c08470fcff3b1bbd3275c1eed64f5a28f
   languageName: node
   linkType: hard
 
@@ -4330,7 +9630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"infer-owner@npm:^1.0.4":
+"infer-owner@npm:^1.0.3, infer-owner@npm:^1.0.4":
   version: 1.0.4
   resolution: "infer-owner@npm:1.0.4"
   checksum: 2020f6d0322e7910ce841134a303c69857e456531d8cd01e336f6eea18122d1085b93ebde961745e5f278233f7f8a3d8b60b9276c8dbd3f49c4c352582ec9504
@@ -4347,10 +9647,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.0, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: ca76c7e45ec715bfe6c1dd67b780b9a15068f37b37ab56cf8b773537b2654238469a42950f5f4d301212755e7512be888f627752e778e1863d95cfedefc8b8bd
+  languageName: node
+  linkType: hard
+
+"inherits@npm:2.0.1":
+  version: 2.0.1
+  resolution: "inherits@npm:2.0.1"
+  checksum: ca9f582ce358ff0a17cdb43f7eb137afa8a109131a934769228ed46ccdc5c2b029476a39ec74581def90ae69b81d603bacb134dff5447f3ad7d15653c513dda6
+  languageName: node
+  linkType: hard
+
+"inherits@npm:2.0.3":
+  version: 2.0.3
+  resolution: "inherits@npm:2.0.3"
+  checksum: e29e5e9b9fd21e3fdf5e138c99b7328965c14e59abb31dcaec6eb81744597c52ad3b2ac3bf0fc73e1c397883f077bb52fbd98724ad5a49b4750f3de594f74c2f
   languageName: node
   linkType: hard
 
@@ -4358,6 +9672,13 @@ __metadata:
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: 37fad549288bc1d016dce7360166c87d28cd1e3ca4077bd30a1bd648285b9a4f6212062a121bec0f06673687a23642b1f945e940998055427c8c15fead710c3a
+  languageName: node
+  linkType: hard
+
+"inline-style-parser@npm:0.1.1":
+  version: 0.1.1
+  resolution: "inline-style-parser@npm:0.1.1"
+  checksum: 492eab2465f2552dfdd5baec224e90aaf937fb28474ca908a306773a7f0d6025308e62f27124b7c120549ea3a210e938ac930da5c5217df8a23a13cee3e44b4e
   languageName: node
   linkType: hard
 
@@ -4372,6 +9693,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"interpret@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "interpret@npm:2.2.0"
+  checksum: 1451c590e83ef48d423df24f0ecb303fad014a748957e607d7e215bcfe24e5f5ba8c3eb7a006bbff74cb3952fc1be3925ab4f925e4a166edb799ba247db2b88e
+  languageName: node
+  linkType: hard
+
 "ip@npm:^2.0.0":
   version: 2.0.0
   resolution: "ip@npm:2.0.0"
@@ -4379,7 +9707,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-alphabetical@npm:^1.0.0":
+"ipaddr.js@npm:1.9.1":
+  version: 1.9.1
+  resolution: "ipaddr.js@npm:1.9.1"
+  checksum: 5b70543172617fc9b0456f153d197a4fe2df54d1c808ebb17ee85e3cbcb73cf7159a29288d2f10be294f796bcb0695940d7881f8532c3b2928c8f22a97779d00
+  languageName: node
+  linkType: hard
+
+"is-accessor-descriptor@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "is-accessor-descriptor@npm:0.1.6"
+  dependencies:
+    kind-of: "npm:^3.0.2"
+  checksum: 2d1d859ecf3bd5a57566d2425f23fc9cc06f7b43d05ba87dd6cd2abbd8c3ae682fbf77778012964b9a6e9e3e0f461b1d270ba9fbdd021aeb46c94366f1cf58c4
+  languageName: node
+  linkType: hard
+
+"is-accessor-descriptor@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-accessor-descriptor@npm:1.0.0"
+  dependencies:
+    kind-of: "npm:^6.0.0"
+  checksum: fbc53a6000984e1a135a5deaaec23193e59dbad5489e198d0ad2564ab875104c751808e2d57d361307365fcd14e8231b01806945e5075c925ac6dcc8e7382428
+  languageName: node
+  linkType: hard
+
+"is-alphabetical@npm:1.0.4, is-alphabetical@npm:^1.0.0":
   version: 1.0.4
   resolution: "is-alphabetical@npm:1.0.4"
   checksum: 851172d7bbd63d22f86c94b749718d99983b3d7fc2381823e7ebeca7eb4c4d756d42388e7d94a665f856e94681b29f43b16f4f6fdd0a48f119757d5ae94575e2
@@ -4393,6 +9746,16 @@ __metadata:
     is-alphabetical: "npm:^1.0.0"
     is-decimal: "npm:^1.0.0"
   checksum: 6741543b2d6530f73297dc12fe02fb593b12310421d6b98498f229ac4dd02376cfe17ad8759c3427cedff7b8acb188efc9ce2026c1e07cd598d1957031ddd0ee
+  languageName: node
+  linkType: hard
+
+"is-arguments@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "is-arguments@npm:1.1.1"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 3eae41e0267725f644140c795cdcefd265f2ed9f946d4e114b4ccf1f255f42afccfb6f8d79b0124e16cf59ec05841288439435140f9a4450d701f74a271c649c
   languageName: node
   linkType: hard
 
@@ -4412,6 +9775,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-binary-path@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "is-binary-path@npm:1.0.1"
+  dependencies:
+    binary-extensions: "npm:^1.0.0"
+  checksum: 42875481f3f1d98453a02c65b09e8c3165485c0fa63d0a5d13f8df62a3b63e4c08cb9176017943dfce2a72253375878efa7b6dd30d1055aa5dda58dd3accc125
+  languageName: node
+  linkType: hard
+
+"is-binary-path@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "is-binary-path@npm:2.1.0"
+  dependencies:
+    binary-extensions: "npm:^2.0.0"
+  checksum: f6ed933392b85facdc081bbe3539602ac70cf35fe5d3d7e02da0b9c4bc65fa673d815142f16bf6253de84a561332a680382be1ade1406c89c9102832a571620f
+  languageName: node
+  linkType: hard
+
 "is-boolean-object@npm:^1.1.0":
   version: 1.1.2
   resolution: "is-boolean-object@npm:1.1.2"
@@ -4419,6 +9800,20 @@ __metadata:
     call-bind: "npm:^1.0.2"
     has-tostringtag: "npm:^1.0.0"
   checksum: 39616788ace17a15b2a4cbc6bee6dbe96be05e86e6afedf8eb1580a2eb05cd6732dfa58949ebc9343a2c9c389fb8a34a4659e0ef7b5bfc4807ccf9814e0cf9b3
+  languageName: node
+  linkType: hard
+
+"is-buffer@npm:^1.1.5":
+  version: 1.1.6
+  resolution: "is-buffer@npm:1.1.6"
+  checksum: a3857c313fad2bc168a0e0af61d9e8149fe1aa251bc1bb717cf309f8fc3266c2701f82cdf8b224f24e916e32c248da4ead85151ad43c2787090c57b3469f9af7
+  languageName: node
+  linkType: hard
+
+"is-buffer@npm:^2.0.0":
+  version: 2.0.5
+  resolution: "is-buffer@npm:2.0.5"
+  checksum: e3ca83ee43ce9d896ab8389d74b0e5870c960ea06fdbd1e793b4347631038ef12e5494c339fb2645fc3cb18c0e61dda5bb67b2edea2163b20a6b502500c44601
   languageName: node
   linkType: hard
 
@@ -4458,6 +9853,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-data-descriptor@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "is-data-descriptor@npm:0.1.4"
+  dependencies:
+    kind-of: "npm:^3.0.2"
+  checksum: 159a151e93e09b2ac169ce58787afcb00344f9c8e81ed6f1331ea896230da85fa639c914f4ac0840d031c4041a109ec1a4261f097ca09abe8126d588c8c780d3
+  languageName: node
+  linkType: hard
+
+"is-data-descriptor@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-data-descriptor@npm:1.0.0"
+  dependencies:
+    kind-of: "npm:^6.0.0"
+  checksum: 04507e714ad86c5dd4af86d05c39eacd06dfe593f8150731a097754308a64a2a7204d2f2e352c4433a134d2b90696fbd7f4a2c09b0bff8d7180042c6da7b23e7
+  languageName: node
+  linkType: hard
+
 "is-date-object@npm:^1.0.1":
   version: 1.0.5
   resolution: "is-date-object@npm:1.0.5"
@@ -4474,7 +9887,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-docker@npm:^2.0.0":
+"is-descriptor@npm:^0.1.0":
+  version: 0.1.6
+  resolution: "is-descriptor@npm:0.1.6"
+  dependencies:
+    is-accessor-descriptor: "npm:^0.1.6"
+    is-data-descriptor: "npm:^0.1.4"
+    kind-of: "npm:^5.0.0"
+  checksum: 82d53bbddac41765b5003355ef5e34513f9e1a6a20b619b3dc973d0f60b8447f2ab3d42ab9274d26b007c780a21434354582a2768752926ea27dcf4804840a08
+  languageName: node
+  linkType: hard
+
+"is-descriptor@npm:^1.0.0, is-descriptor@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "is-descriptor@npm:1.0.2"
+  dependencies:
+    is-accessor-descriptor: "npm:^1.0.0"
+    is-data-descriptor: "npm:^1.0.0"
+    kind-of: "npm:^6.0.2"
+  checksum: 3536c35fe3db7e9f2e0f7fce901e0be05cf6fc57b5a3d11bea625098757f7f572c5aca4e7792c05bbcebb82b7de2e9a9de60ecf26e79ddc85ac82c631dac8558
+  languageName: node
+  linkType: hard
+
+"is-docker@npm:^2.0.0, is-docker@npm:^2.1.1":
   version: 2.2.1
   resolution: "is-docker@npm:2.2.1"
   bin:
@@ -4483,10 +9918,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-extglob@npm:^2.1.1":
+"is-extendable@npm:^0.1.0, is-extendable@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "is-extendable@npm:0.1.1"
+  checksum: ffa5a697b932aeb992b4471674489fd07c223034e0d8ed4b7ef70a7daab850aaccc09519e40d02a36b98b30f978f38697e53cb32e3d4bc3c3d6af229c47a1822
+  languageName: node
+  linkType: hard
+
+"is-extendable@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-extendable@npm:1.0.1"
+  dependencies:
+    is-plain-object: "npm:^2.0.4"
+  checksum: 6fc68b8c8ada0501262a29a35f2e2c11a550c96a8c3ce6cb2ea12a5f48b3f658b9e28f92f195750e80d6d1732a146269473ae5f0f1fa70d26c6e45e9f5976b5a
+  languageName: node
+  linkType: hard
+
+"is-extglob@npm:^2.1.0, is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
   checksum: 226b9f6eee1e7da52f72c98ed4ea7fc71ee3a087b6d1c62655c9a81c601caa2fd98b9f9be42fb8163eef2720cdbf046bc7c5548a76755651e540f4b08ff3b120
+  languageName: node
+  linkType: hard
+
+"is-finite@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "is-finite@npm:1.1.0"
+  checksum: b029a10ab9d71094a11fd177d05d64401972ac0e44f9da3f084822f41f23146933b733807d6388da6baecad2b20c88e925739d5bcac05d1c166943c44065deda
   languageName: node
   linkType: hard
 
@@ -4504,7 +9962,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
+"is-function@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "is-function@npm:1.0.2"
+  checksum: da2dd9cd27c91ee7d2aa20bcc05d45e6b9a614aba81a7f8e4085321379782ca1b5a8ef2bf9cf09708e0072f8d1d4a057accd409fd5fecb3bd081e13c51fd18d7
+  languageName: node
+  linkType: hard
+
+"is-glob@npm:^3.0.0, is-glob@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "is-glob@npm:3.1.0"
+  dependencies:
+    is-extglob: "npm:^2.1.0"
+  checksum: 8c1dacaba5b67ad5b85578d9c6f29fe9b8a1ca3c96560a3f9c0de6c7f987c1d71b959a7553eafaa981a61cfa0e928bb6d31c527353f44f45dba7d2c3a1b3db87
+  languageName: node
+  linkType: hard
+
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -4524,6 +9998,13 @@ __metadata:
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
   checksum: 8e761e558bf60bd3682648e6ecb6333e9ad9c5a6fef2a9ca879deef1a40478e5f7e18999fc3630ef8b879cf00bc0248ffa5616aa4251917a7f87f066841310aa
+  languageName: node
+  linkType: hard
+
+"is-map@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "is-map@npm:2.0.2"
+  checksum: ffa1914b19d6d5a2bc50ddd28ff9268429053f4b12b7ba511dc4f9fed3ac28391446948b5bef758664dc8b4dc11e24a40398e40666fbd525c75723533a568213
   languageName: node
   linkType: hard
 
@@ -4547,6 +10028,15 @@ __metadata:
   dependencies:
     has-tostringtag: "npm:^1.0.0"
   checksum: fd67ff18bad5c64ce2054a03d92c9f264f0f0cd197ea6951207c3dd1b9bea5b40e933be440e7673ea2f1e2a6b265c1842651c94c12d16efd84bbe9310d9cc600
+  languageName: node
+  linkType: hard
+
+"is-number@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-number@npm:3.0.0"
+  dependencies:
+    kind-of: "npm:^3.0.2"
+  checksum: 8c8ffed73c8ae7103daf066c3ff9be8c702edfdcfb8d0fa5d4b70a3b056ba9aaf4c0d6a055fbbd020cb7c622f30763dd2c3cd71319776f4c6ed1520891b5be0e
   languageName: node
   linkType: hard
 
@@ -4578,6 +10068,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-obj@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "is-plain-obj@npm:2.1.0"
+  checksum: d07f99715f51b58ef452a809a416bd75da7ea10152f53adf469dd30b1e262e60f6f9c1182534a7ceb3e82a5516cd9aa9548d6dfd5df7ce03f6298b19691c81df
+  languageName: node
+  linkType: hard
+
+"is-plain-object@npm:5.0.0":
+  version: 5.0.0
+  resolution: "is-plain-object@npm:5.0.0"
+  checksum: fd152d0cadce30fc41b1294e5e63a6bc696a82102828d77e63cf9eb01510c011c9c2ca432babb372356ac24ec164427ecf0c9633a4ea044b4de18d92be013700
+  languageName: node
+  linkType: hard
+
+"is-plain-object@npm:^2.0.3, is-plain-object@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "is-plain-object@npm:2.0.4"
+  dependencies:
+    isobject: "npm:^3.0.1"
+  checksum: fd67792beb6982bbf5d0b0e8e0f743947d0ca6a1068e20b4826d47e7d7b674fdd4860e4c685880081ea3cedb03aeddf55037500ca7d9ee09335908118b46782f
+  languageName: node
+  linkType: hard
+
 "is-reference@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-reference@npm:1.2.1"
@@ -4587,13 +10100,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.1.4":
+"is-regex@npm:^1.1.2, is-regex@npm:^1.1.4":
   version: 1.1.4
   resolution: "is-regex@npm:1.1.4"
   dependencies:
     call-bind: "npm:^1.0.2"
     has-tostringtag: "npm:^1.0.0"
   checksum: d5a09a3da9ba262b3c92f415a2d917ff42fb2241ec7a6cc58ac4512b1b4b35da765c79a60677d7125467a0a597f90cc8d20c5472da520d20476dd12b663cfa65
+  languageName: node
+  linkType: hard
+
+"is-set@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "is-set@npm:2.0.2"
+  checksum: 09fa41ce849885c733d98f35c0ff1a24073fd5f920ef6201aa64ae054516f9b07af4d10282b2890ed098ed360538a22ab296d08ff9a4191baf318fa682c8c4e5
   languageName: node
   linkType: hard
 
@@ -4654,6 +10174,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-utf8@npm:^0.2.0":
+  version: 0.2.1
+  resolution: "is-utf8@npm:0.2.1"
+  checksum: 33edd368af5530114a9d6b94ebf5dfcf043807267769223bb411b22c04a6c4f99a9a000c8e7538f3c6b8393f97d4919f0902dcfca8034e07464de53d72471ec1
+  languageName: node
+  linkType: hard
+
 "is-weakref@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-weakref@npm:1.0.2"
@@ -4663,7 +10190,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-wsl@npm:^2.2.0":
+"is-whitespace-character@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-whitespace-character@npm:1.0.4"
+  checksum: ec3425902559764e29d6ec205d6fd2e395413a46550c5fb832d3f5cb92fcbd4eaff5d017cc20ba6ff666d2b14d0a0b3380cbde525da64474125b9db2bf651163
+  languageName: node
+  linkType: hard
+
+"is-windows@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "is-windows@npm:1.0.2"
+  checksum: ba7ae056a6a1ab995164ff9212cb7ddc764669144dae7c9d6e34431fc36ec2d3a6a831855a0ac21fb80d4a44e8dc2223437aa68999920fc113b662306bbc776c
+  languageName: node
+  linkType: hard
+
+"is-word-character@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-word-character@npm:1.0.4"
+  checksum: d9377d1168afb0a0b9b504c2a9dfcda8419dc1fd743315f6dbf753fb0bee411aedd6f33ea5619caef01ddb2beb52da7faf2a45560cafb8c6a5ea9a87c7cfc1bb
+  languageName: node
+  linkType: hard
+
+"is-wsl@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "is-wsl@npm:1.1.0"
+  checksum: 8d139a28f57a6e6ef262f4e0f34142d6ad3dd13db8e497b4fef09d3e037b0a3971c527922e3c44fc14fba54e1a620a15d0f89da73e6c7cce11b6ccbf72f02001
+  languageName: node
+  linkType: hard
+
+"is-wsl@npm:^2.1.1, is-wsl@npm:^2.2.0":
   version: 2.2.0
   resolution: "is-wsl@npm:2.2.0"
   dependencies:
@@ -4672,10 +10227,124 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isarray@npm:1.0.0, isarray@npm:^1.0.0, isarray@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "isarray@npm:1.0.0"
+  checksum: 7b41a2a80d6285328dddeecd3e45a5c73264e8ff8817bb7dc39f6f47323dfaa28e27c13918aac4aa88e48800a4f1eee2e5e966da433e06085ef0a7592dcf6880
+  languageName: node
+  linkType: hard
+
+"isarray@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "isarray@npm:2.0.5"
+  checksum: bd46a907ad163c4c937d08ee6520fc9482cf5457dc0d168457ef755d8f26e75b5e2649962722a4c0f5ab2398a95e431c8469c86a004c42db21230ef40b8720ee
+  languageName: node
+  linkType: hard
+
 "isexe@npm:^2.0.0":
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
   checksum: b37fe0a7983c0c151c7b31ca716405aaea190ac9cd6ef3f79355f4afb043ed4d3182a6addd73b20df7a0b229269737ad0daf64116821a048bfbe6b8fb7eb842c
+  languageName: node
+  linkType: hard
+
+"isobject@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "isobject@npm:2.1.0"
+  dependencies:
+    isarray: "npm:1.0.0"
+  checksum: 99df852e57e1ab7ec863ad56affadd024944607da525e78c430b813bb2c901f95321c689c9617852c50f808a6b61f2f90246c61df6d32f69f09f80af7f97a145
+  languageName: node
+  linkType: hard
+
+"isobject@npm:^3.0.0, isobject@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "isobject@npm:3.0.1"
+  checksum: 63ee4c1b8002898c138728082399ad3f3f77f6e2f1ee8cc286bb4641aebcaaecb0931c608a64525471a95356daf42ea35b2f2610e15ea2c9ba6a6b4ab7b909fc
+  languageName: node
+  linkType: hard
+
+"isobject@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "isobject@npm:4.0.0"
+  checksum: 4107b1e70dba6ad22236b6c661fbaa1f80e3fd83646a1136a0b4721ee71cdfa98c0cec619f25be415bcda9081b54a17f238cb92cd085371e50a9222a7a5640e4
+  languageName: node
+  linkType: hard
+
+"isomorphic-unfetch@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "isomorphic-unfetch@npm:3.1.0"
+  dependencies:
+    node-fetch: "npm:^2.6.1"
+    unfetch: "npm:^4.2.0"
+  checksum: 0e2c983e6bdefb502ef82a9345b04560cc2d18f39b0dac61be26849cfe8479102255d8e0b55c87ecd7f091c2aa7433257fb338df23e3875ba7954a3411bb29c1
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "istanbul-lib-coverage@npm:3.2.0"
+  checksum: a763d8be15991de6b4c4e99727126a0fd4da3a3d87577a1e42c8856674f361472196f8db7307801b35a294f48ffcf66c6cc45f34086ca58015f16a9fc9fc04f6
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "istanbul-lib-report@npm:3.0.0"
+  dependencies:
+    istanbul-lib-coverage: "npm:^3.0.0"
+    make-dir: "npm:^3.0.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 9b728ea9453bbefa7d872f1522d389b5cb107990e403849e9caabee7851d3c072abab655a18810879660ed986922ad7551e886bc1aa6f909248d0f3b951813ab
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.1.4":
+  version: 3.1.5
+  resolution: "istanbul-reports@npm:3.1.5"
+  dependencies:
+    html-escaper: "npm:^2.0.0"
+    istanbul-lib-report: "npm:^3.0.0"
+  checksum: 1dbb467f79cdc6498b27b4579a00f0faeea03678af0f92f4705e8877095043b258e8022e036cae8ee524dbf1eb5615281c92da1fb5b88706642ab865eea71b8a
+  languageName: node
+  linkType: hard
+
+"iterate-iterator@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "iterate-iterator@npm:1.0.2"
+  checksum: 3e586e73cedcdbac9c7d5c2b9b6d961f9b4b7920c8d68468ac2801f41dedfa9c4cc9f81ffef05fbb2ea035ba78aeb871b5a4562345fd9c38046e9617d2dd94d0
+  languageName: node
+  linkType: hard
+
+"iterate-value@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "iterate-value@npm:1.0.2"
+  dependencies:
+    es-get-iterator: "npm:^1.0.2"
+    iterate-iterator: "npm:^1.0.1"
+  checksum: 3aa4975cfd578efa26d4cbe4e4dee3ae761ec62f2f0a9f4ee625829b8509460bfbd6dae713ae9b70d2b9775605173e90b13c65afe0d114b00ecf5f9611b7584f
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^26.5.0":
+  version: 26.6.2
+  resolution: "jest-worker@npm:26.6.2"
+  dependencies:
+    "@types/node": "npm:*"
+    merge-stream: "npm:^2.0.0"
+    supports-color: "npm:^7.0.0"
+  checksum: 244d4034e43b47cfae2c896ce9273d18597dc18648ca7d7974c522fb3fe61f5bd91a2dae22222c710c5f14f17fbc3033656cca92fb64fd9e677f77e7a66caf62
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^27.4.5":
+  version: 27.5.1
+  resolution: "jest-worker@npm:27.5.1"
+  dependencies:
+    "@types/node": "npm:*"
+    merge-stream: "npm:^2.0.0"
+    supports-color: "npm:^8.0.0"
+  checksum: dc5167cc25813211fd1920be69c32c71afcb7b8bff117b87669cc445fdfdb086d84b61e4cdd69bf310705ec453354753930b4f64cf40b9d4f6f1e1c28c86543e
   languageName: node
   linkType: hard
 
@@ -4692,6 +10361,13 @@ __metadata:
   version: 3.1.1
   resolution: "joycon@npm:3.1.1"
   checksum: a51b680763b484e3bc516a33e959db12fb61fa8f58130e060151e8412607256b3647d97d5a16e66bd990d8a4a319a36b185af3f119340c4362c06faf38900d08
+  languageName: node
+  linkType: hard
+
+"js-string-escape@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "js-string-escape@npm:1.0.1"
+  checksum: d764658fa4d88ef206950f7f597a22daea612f60834e7877d5447d71bf37ff7b4b0482895df6e52cf171465b825ac25cd93e9a0e3d7c28706475efd27e729b17
   languageName: node
   linkType: hard
 
@@ -4729,7 +10405,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-parse-even-better-errors@npm:^2.3.0":
+"jsesc@npm:~0.5.0":
+  version: 0.5.0
+  resolution: "jsesc@npm:0.5.0"
+  bin:
+    jsesc: bin/jsesc
+  checksum: cba3a1fba9401771cf3bad85c8e0e2c604cfdfd85d7b1a7a8ae84317777f76c4b02d6c52da86cb8a70307ca84c3aa40a214e77bf0d5549557826b04df6df2bdf
+  languageName: node
+  linkType: hard
+
+"json-parse-better-errors@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "json-parse-better-errors@npm:1.0.2"
+  checksum: b5aa5ddfd40eca6bf2d224d9daa7b92849fb9e5c8c91eaeb427ee03cdd3fa25847d19187580971208ec20bc9fdc6b35770c8b1786a8b83ef22710f03e717d45a
+  languageName: node
+  linkType: hard
+
+"json-parse-even-better-errors@npm:^2.3.0, json-parse-even-better-errors@npm:^2.3.1":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: ba9ec77806c99530719c8c2a26aa426f421dccd6faafb4ee32f2d71dff25aefe4d150fba814eb58be8b82e765af5e7dc8e88d1c38c7227a1304f4d20a405a67a
@@ -4757,7 +10449,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.1":
+"json5@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "json5@npm:1.0.1"
+  dependencies:
+    minimist: "npm:^1.2.0"
+  bin:
+    json5: lib/cli.js
+  checksum: fd9492140ea8a1ec338c96e8527e940c9464ca3c7ef8fbf00b8bbbac1c6e60d612bf6640885e8a9108c3b71dc913f9a07a628df36f462853ea8c59bbce192e32
+  languageName: node
+  linkType: hard
+
+"json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.1":
   version: 2.2.1
   resolution: "json5@npm:2.2.1"
   bin:
@@ -4815,10 +10518,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kind-of@npm:^6.0.3":
+"junk@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "junk@npm:3.1.0"
+  checksum: de68c0ba2ed2c4478c38d116fa31aa2aff60c9e839fa5dd471ef504a5433590d10ada84f96dc1b516ff87f261b24ee844ad55bdcf196b4df977f561293a9aec9
+  languageName: node
+  linkType: hard
+
+"kind-of@npm:^3.0.2, kind-of@npm:^3.0.3, kind-of@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "kind-of@npm:3.2.2"
+  dependencies:
+    is-buffer: "npm:^1.1.5"
+  checksum: 0d9abb42418672d172161162a115633d0b0573837e649fe7f41e492708a2dbaf41a4f6bee041ca1a54639631355f77d414e308221ac6e2ea2e7552d26507597c
+  languageName: node
+  linkType: hard
+
+"kind-of@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "kind-of@npm:4.0.0"
+  dependencies:
+    is-buffer: "npm:^1.1.5"
+  checksum: 3e64797b13ff40f96b8f04e09cf907460725770904e90e0d22fbc5fddbedab44520b6a6d7040c449231b5576dddebec588ace9ca294642410650269dea7772f5
+  languageName: node
+  linkType: hard
+
+"kind-of@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "kind-of@npm:5.1.0"
+  checksum: a2d405abf3554b8ecb90941e5209d5d3712417e98dc4491e57acc509c8033dde1ed720103bd4337bf43b909fc00970524ad1e7f73d7f51f899653f83c17c5d52
+  languageName: node
+  linkType: hard
+
+"kind-of@npm:^6.0.0, kind-of@npm:^6.0.2, kind-of@npm:^6.0.3":
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
   checksum: 4adceee06111de8a2d02e7b542c957caad38f2d54c522da0387f4735804bf1819b2ccd918c8d1c8a73276caf9d728fc8276b53e142d23879c4728a6edcbdf722
+  languageName: node
+  linkType: hard
+
+"kleur@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "kleur@npm:3.0.3"
+  checksum: 91b79c93267542395ca98bed81ba1e10184de1738734938fdc2ac36c6884e75e8ca9e232d8a411056b4339904c47d0162795e66674cafa210fd5c2b0d930e1a4
+  languageName: node
+  linkType: hard
+
+"klona@npm:^2.0.4":
+  version: 2.0.5
+  resolution: "klona@npm:2.0.5"
+  checksum: a4dcd9c0ea136553a0343f57e8da6b9d4cc0275e54711061c46ef12b2b890e88e830ff67e853d738cb1b3e7049426cda203592abb39fcb2ef724526fb5fa139f
   languageName: node
   linkType: hard
 
@@ -4829,6 +10578,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lazy-universal-dotenv@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "lazy-universal-dotenv@npm:3.0.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.5.0"
+    app-root-dir: "npm:^1.0.2"
+    core-js: "npm:^3.0.4"
+    dotenv: "npm:^8.0.0"
+    dotenv-expand: "npm:^5.1.0"
+  checksum: 4a84e950a9e39f127cf7421145f8b63a6edf41acebae2b83366ae63f5285b626f4a8a5ae335ff44476f9d8cbcb4f12cccbc3c7aa52b00cf7d52b6d67d030c8a2
+  languageName: node
+  linkType: hard
+
 "levn@npm:^0.4.1":
   version: 0.4.1
   resolution: "levn@npm:0.4.1"
@@ -4836,6 +10598,16 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: b281df6770286ddce58d431441772b75ec04f03264af49532c330fdbe070795196538459754cb9e564e7759dbd79c2f88fab01bb3295b2a70249d1a777016cb4
+  languageName: node
+  linkType: hard
+
+"levn@npm:~0.3.0":
+  version: 0.3.0
+  resolution: "levn@npm:0.3.0"
+  dependencies:
+    prelude-ls: "npm:~1.1.2"
+    type-check: "npm:~0.3.2"
+  checksum: ca790d4b61d6ae2357b4e33f5a5da663c403c796f572b90f4fd9f1afd3cd71cf29903905638f81d7c5cb585619ae1d7f959deb0c86802bae02ba37c14a0902a8
   languageName: node
   linkType: hard
 
@@ -4906,10 +10678,69 @@ __metadata:
   languageName: node
   linkType: hard
 
+"load-json-file@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "load-json-file@npm:1.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.2"
+    parse-json: "npm:^2.2.0"
+    pify: "npm:^2.0.0"
+    pinkie-promise: "npm:^2.0.0"
+    strip-bom: "npm:^2.0.0"
+  checksum: df1a8bbf7b3be57c50e67dc5dc2d361d9c00a13d47be74997bacfc7a0b46d4ed704131191dcd2480587bd6df8626697f2a534b6d6a8bab3e0abb83e4f8e40ed7
+  languageName: node
+  linkType: hard
+
+"loader-runner@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "loader-runner@npm:2.4.0"
+  checksum: 7eaf0b911593f5b5c5cc5a6211150bd937156d9b4a16b6f17d8a7d9381fac0ca72b17fba1456a59f5e5bebb2128a6b9d28441c8c6e26ab06294bb071b8b0d3cb
+  languageName: node
+  linkType: hard
+
+"loader-runner@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "loader-runner@npm:4.3.0"
+  checksum: 933f44df27137a0b3f06928615c9af8d3cde7086e46c23afb25e218f168bc4e9827cb1a9cebe15edb71df3562a97a70c37edadb80c5050fbd2135f85b16a5874
+  languageName: node
+  linkType: hard
+
+"loader-utils@npm:^1.2.3":
+  version: 1.4.0
+  resolution: "loader-utils@npm:1.4.0"
+  dependencies:
+    big.js: "npm:^5.2.2"
+    emojis-list: "npm:^3.0.0"
+    json5: "npm:^1.0.1"
+  checksum: ba50c7c77159d1f07d8d583b301fdd7f6b02101503b4057bb0cfbe474ce6aeb95d437a5f902fd969787177be740abbb058c2d5df686acaecd2a38e4ebad46a3c
+  languageName: node
+  linkType: hard
+
+"loader-utils@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "loader-utils@npm:2.0.2"
+  dependencies:
+    big.js: "npm:^5.2.2"
+    emojis-list: "npm:^3.0.0"
+    json5: "npm:^2.1.2"
+  checksum: ccb4bf2d75ed9689688b93934e6659c2846b2de5e2c9a6e7e71b2b6863e54ba5c7e285a5c9936ad93b87a7a3323dc46380266858cbff3ae757f3a20611092304
+  languageName: node
+  linkType: hard
+
 "local-pkg@npm:^0.4.2":
   version: 0.4.2
   resolution: "local-pkg@npm:0.4.2"
   checksum: d81176965ca55952dc78d9cb5712db7106535bf0c8d62c8b288b61ead0c82a3bd7e4855ec8cf18c3ea94e0ed8a802c6600d11ed17b6588d9d66e67ce268d023c
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "locate-path@npm:3.0.0"
+  dependencies:
+    p-locate: "npm:^3.0.0"
+    path-exists: "npm:^3.0.0"
+  checksum: ca3f5b4f7f8f9dc8f650b7a9ced56babaeeb3da4b34eea236cc75a62ac69626aa13b784685d3a9d6e8ce383c8921912823c8a2d16cd8cd68a0484d8ca8d98e09
   languageName: node
   linkType: hard
 
@@ -4931,6 +10762,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.debounce@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "lodash.debounce@npm:4.0.8"
+  checksum: 960a803d892fc09976e7b559c36407000c3beb136cf20e88ae6a694b5d7cf64e31dde516079140a945ba695b7d5e5699444d61fd13a70ff7de409bbae7604005
+  languageName: node
+  linkType: hard
+
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
@@ -4938,7 +10776,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21":
+"lodash.uniq@npm:4.5.0":
+  version: 4.5.0
+  resolution: "lodash.uniq@npm:4.5.0"
+  checksum: 8ac56bbaa8a4ccd0dd8b9cabdcee89dfb382f8907fdb6ac12d40d46298c7b4de74c6bdab3a9e6fb4f0307568a67220f9ce86270e17dd8b628a312be9ee3a4767
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.17.11, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 3ac18e92108d68f88429fcddee609e42cf2b653583d9bac22308815a4cd6b185b89a0ad0d9b0c670c371d9d6b61571a98fee6b36e1db14e52766ca253ed9cba0
@@ -4968,12 +10813,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loud-rejection@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "loud-rejection@npm:1.6.0"
+  dependencies:
+    currently-unhandled: "npm:^0.4.1"
+    signal-exit: "npm:^3.0.0"
+  checksum: 593194ce2617035fabb576166ee7a582a102665fbddf75d1bbc7920356c83f5b1a99330e2c1c7902a018efa62c3d4850d812cf99839cfd9b9372bb422d81a62c
+  languageName: node
+  linkType: hard
+
 "loupe@npm:^2.3.1":
   version: 2.3.4
   resolution: "loupe@npm:2.3.4"
   dependencies:
     get-func-name: "npm:^2.0.0"
   checksum: 2b55151a85163147adcb7e656d34cb3eafde4831566671fa046bb6c2cc4fc0d577451609a65b8ff3c9f2a36c7f06c70bce4df19db9da517eec28f8a9262c46ff
+  languageName: node
+  linkType: hard
+
+"lower-case@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "lower-case@npm:2.0.2"
+  dependencies:
+    tslib: "npm:^2.0.3"
+  checksum: 2da56ea650669ee9d2427ba349867da18b4cf0190be2fb2b0f8adaa28cffd27bbf4e39b41a619bf653906a584b84c7df606b7f727d3048a8056e4e419407b3e5
+  languageName: node
+  linkType: hard
+
+"lowlight@npm:^1.17.0":
+  version: 1.20.0
+  resolution: "lowlight@npm:1.20.0"
+  dependencies:
+    fault: "npm:^1.0.0"
+    highlight.js: "npm:~10.7.0"
+  checksum: 9885f806d2046b03388f02cee52717ba46478582885ed636b66e5057b236ab5138c4628fe8c0494e34b360a048e3b34e571a74a3e490ab7b3c1e5310f1181c3c
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "lru-cache@npm:5.1.1"
+  dependencies:
+    yallist: "npm:^3.0.2"
+  checksum: 7e3274d0936ac64611d0053664b5c722f2b869c4962a007752251602020345f385885cfeabd0162aa45c7d2ee8a21f461d9d628db348f553c126126b170ad6d2
   languageName: node
   linkType: hard
 
@@ -5011,7 +10894,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^3.0.0":
+"make-dir@npm:^2.0.0, make-dir@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "make-dir@npm:2.1.0"
+  dependencies:
+    pify: "npm:^4.0.1"
+    semver: "npm:^5.6.0"
+  checksum: be9cf8f5e285f4ba5cd354a60ded821c7cf05622355403ad33704c3e1dba0fdf2b756c90536319ed3dcd5e73bd01b64fd9c0e8f14907bc5257e5890b598233cb
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^3.0.0, make-dir@npm:^3.0.2, make-dir@npm:^3.1.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
   dependencies:
@@ -5051,7 +10944,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"map-obj@npm:^1.0.0":
+"map-cache@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "map-cache@npm:0.2.2"
+  checksum: b2ab6a18f1157adb0ab9a8a2990c875d7104f8f1a90f306d386700f253ae81df69efde42fdc42687c482148a60fc20e5f647361b33f52dd51c2cafa695c60fdd
+  languageName: node
+  linkType: hard
+
+"map-obj@npm:^1.0.0, map-obj@npm:^1.0.1":
   version: 1.0.1
   resolution: "map-obj@npm:1.0.1"
   checksum: 68110c982ea7d80ccac49d93a53529a295a27cf9c392d15f7b5c42b26c3760a33abe7d4163cdaf6e5be023f514e541e36ab604ef42b8c6c7978f6433e826f8dc
@@ -5062,6 +10962,29 @@ __metadata:
   version: 4.3.0
   resolution: "map-obj@npm:4.3.0"
   checksum: f87dd958d20a51488dfc3c933c5a64bad4e33053a05bc2c4c431a99e9cb1a5a6096a39cf2f7f5235c6a4540f534d3ff2ecf63664718b8e28f9da7026deda0833
+  languageName: node
+  linkType: hard
+
+"map-or-similar@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "map-or-similar@npm:1.5.0"
+  checksum: d37258b613b94ba7e3d4a4f8166f60b3818209ba70e4a997e05355c173a1bc5d1471090162b11d2aaa69601e00fca9546e6fb15c345630c36caba0472ff7173d
+  languageName: node
+  linkType: hard
+
+"map-visit@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "map-visit@npm:1.0.0"
+  dependencies:
+    object-visit: "npm:^1.0.0"
+  checksum: f32be05b8e221dbdd2d629b89b55b4ca37449ff46c760c5605d2fcfa757743ea3ed3a146f9ee88225f468ef607eac9e8eb1585b422be6a37444f33473e9d168f
+  languageName: node
+  linkType: hard
+
+"markdown-escapes@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "markdown-escapes@npm:1.0.4"
+  checksum: c17e144fe369cc42b9efadd25daca1f08b93a7903870c8af465914d58fcce37890cf30ba5c44b5689572886ae920f97d5ea7e35784dad53f230ab64c11d4f2b7
   languageName: node
   linkType: hard
 
@@ -5089,6 +11012,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"md5.js@npm:^1.3.4":
+  version: 1.3.5
+  resolution: "md5.js@npm:1.3.5"
+  dependencies:
+    hash-base: "npm:^3.0.0"
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.1.2"
+  checksum: 8ef352bbd030e0c1332da88131232adedf908e9fa5b3de383acc8e6e56f92e98fdb53e2903497e0c89e501a5b3838db0fb29ac1f54b389155b394e7feb06dace
+  languageName: node
+  linkType: hard
+
+"mdast-squeeze-paragraphs@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mdast-squeeze-paragraphs@npm:4.0.0"
+  dependencies:
+    unist-util-remove: "npm:^2.0.0"
+  checksum: 2df1b63a693fd3330a9f23466c11fbef09c59c4cdca06ce208e29d724fed5f8858b4337a540e0b1ab281dbd254e14553c88a644b3b932587fe605d2ee218bbf0
+  languageName: node
+  linkType: hard
+
+"mdast-util-definitions@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mdast-util-definitions@npm:4.0.0"
+  dependencies:
+    unist-util-visit: "npm:^2.0.0"
+  checksum: 8b9847efa26289a6859a69fc824a14298c1187876171407831b0d6bce79d7d8c2611363f6273eea909d2ddcc1c299a89cfefb5f741061e3dd83505b783b8cb54
+  languageName: node
+  linkType: hard
+
 "mdast-util-from-markdown@npm:^0.8.5":
   version: 0.8.5
   resolution: "mdast-util-from-markdown@npm:0.8.5"
@@ -5102,6 +11054,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-to-hast@npm:10.0.1":
+  version: 10.0.1
+  resolution: "mdast-util-to-hast@npm:10.0.1"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    "@types/unist": "npm:^2.0.0"
+    mdast-util-definitions: "npm:^4.0.0"
+    mdurl: "npm:^1.0.0"
+    unist-builder: "npm:^2.0.0"
+    unist-util-generated: "npm:^1.0.0"
+    unist-util-position: "npm:^3.0.0"
+    unist-util-visit: "npm:^2.0.0"
+  checksum: 54d6da4bbcc75b07ab997601994055f8ad981138aba86b818e8092c2693e391297442fd4958dc3faf61393a3b6f012bb02ff2e10be932a1f68829d890235378f
+  languageName: node
+  linkType: hard
+
 "mdast-util-to-string@npm:^2.0.0":
   version: 2.0.0
   resolution: "mdast-util-to-string@npm:2.0.0"
@@ -5109,10 +11077,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdurl@npm:^1.0.1":
+"mdurl@npm:^1.0.0, mdurl@npm:^1.0.1":
   version: 1.0.1
   resolution: "mdurl@npm:1.0.1"
   checksum: de89d573bab7a689c8f24680ec7612d60c2858ec9527738312737845c0890d6b36832cd1a95cfe5c590c694cd96a7ca3e4dc9bf8d7f7048906ba8f8049929a02
+  languageName: node
+  linkType: hard
+
+"media-typer@npm:0.3.0":
+  version: 0.3.0
+  resolution: "media-typer@npm:0.3.0"
+  checksum: 21806e15268f71b2bbf35a57b5eb9a42e14be638b8b855e210fb90282744e622f9d232f34f1cf566dc487819ce66bbb8aa6568e3267f48b12e92e2ba679838ae
+  languageName: node
+  linkType: hard
+
+"memfs@npm:^3.1.2":
+  version: 3.4.7
+  resolution: "memfs@npm:3.4.7"
+  dependencies:
+    fs-monkey: "npm:^1.0.3"
+  checksum: 106ad7da93ca9fcdbf627358b62545bd2ea1d9a6a0cabace639e852b33ade5e92b84509e8592a5c439c38045d208410db403ebca1089178b789964e893e4f235
+  languageName: node
+  linkType: hard
+
+"memoizerific@npm:^1.11.3":
+  version: 1.11.3
+  resolution: "memoizerific@npm:1.11.3"
+  dependencies:
+    map-or-similar: "npm:^1.5.0"
+  checksum: 5c4f30a3810f3ceffdf0df2ef28989e3535eb4c05a614b791b57d92c662ad6d0f08d971b21991e2d9931d6c9efe7fd560899d9718a713947d5489855c8d29a1f
+  languageName: node
+  linkType: hard
+
+"memory-fs@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "memory-fs@npm:0.4.1"
+  dependencies:
+    errno: "npm:^0.1.3"
+    readable-stream: "npm:^2.0.1"
+  checksum: 1ab5bd4a17e8f07e0ad62cb96506955b6d22afaf3a1866ea4dd6016849f8603417af0a568c2cbf799087578f0a87b6f8d61d43907dc335f4c796cdab023ccff6
+  languageName: node
+  linkType: hard
+
+"memory-fs@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "memory-fs@npm:0.5.0"
+  dependencies:
+    errno: "npm:^0.1.3"
+    readable-stream: "npm:^2.0.1"
+  checksum: 932fe92e5fd3164514746e1364d3f806b9a19a0c99913df7ffc964a48833bcdf6792dcf497ef322c99a201b81987cbd03ab3a9c42391b01ef9af638b805cec41
   languageName: node
   linkType: hard
 
@@ -5136,6 +11149,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"meow@npm:^3.1.0":
+  version: 3.7.0
+  resolution: "meow@npm:3.7.0"
+  dependencies:
+    camelcase-keys: "npm:^2.0.0"
+    decamelize: "npm:^1.1.2"
+    loud-rejection: "npm:^1.0.0"
+    map-obj: "npm:^1.0.1"
+    minimist: "npm:^1.1.3"
+    normalize-package-data: "npm:^2.3.4"
+    object-assign: "npm:^4.0.1"
+    read-pkg-up: "npm:^1.0.1"
+    redent: "npm:^1.0.0"
+    trim-newlines: "npm:^1.0.0"
+  checksum: 392cd47b21ef72ce5d2998df8b0fc2b9286db0a411935acfd44c225b8f4860f25e7f0f48d8389cb920fd97790bc6b09a4ac29e468393943f5202933f262534fe
+  languageName: node
+  linkType: hard
+
 "meow@npm:^8.0.0":
   version: 8.1.2
   resolution: "meow@npm:8.1.2"
@@ -5155,6 +11186,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"merge-descriptors@npm:1.0.1":
+  version: 1.0.1
+  resolution: "merge-descriptors@npm:1.0.1"
+  checksum: 6c8d19415ddd30b17ebd8e4474897549915cb90bb1caa13bbc55cce27a72d377c289abd300a3e8c6c1a6d61c4ea1fbe297addf032a9d75cb8de2788bc8b9cb2c
+  languageName: node
+  linkType: hard
+
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -5162,10 +11200,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.3.0, merge2@npm:^1.4.1":
+"merge2@npm:^1.2.3, merge2@npm:^1.3.0, merge2@npm:^1.4.1":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: d58d7c31e24ccb93509def2af306eca9a55ad8b8862a26ea7deda3c9338e5d33365f57197ad37af68c319e5e2a1faf089e5d05894d0dc29ff07025b30b8ff8b0
+  languageName: node
+  linkType: hard
+
+"methods@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "methods@npm:1.1.2"
+  checksum: 4641d1eda8231aee6774d28a32249f1d4f04e2a58a86c4a968eed39d178d64594ed829301eb603356decc9bd423eacd68d6bde7874a291475800a1568e547d4e
+  languageName: node
+  linkType: hard
+
+"microevent.ts@npm:~0.1.1":
+  version: 0.1.1
+  resolution: "microevent.ts@npm:0.1.1"
+  checksum: 6a404b25204400a4a4e587ba694b1b009297e9693cbccb7763e65555168faf5cbafbf52878b5b4778e5aa70fed6f54b6443717135fda441a4a2c8c73843b976a
   languageName: node
   linkType: hard
 
@@ -5179,7 +11231,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:4.0.5, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
+"micromatch@npm:^3.1.10, micromatch@npm:^3.1.4":
+  version: 3.1.10
+  resolution: "micromatch@npm:3.1.10"
+  dependencies:
+    arr-diff: "npm:^4.0.0"
+    array-unique: "npm:^0.3.2"
+    braces: "npm:^2.3.1"
+    define-property: "npm:^2.0.2"
+    extend-shallow: "npm:^3.0.2"
+    extglob: "npm:^2.0.4"
+    fragment-cache: "npm:^0.2.1"
+    kind-of: "npm:^6.0.2"
+    nanomatch: "npm:^1.2.9"
+    object.pick: "npm:^1.3.0"
+    regex-not: "npm:^1.0.0"
+    snapdragon: "npm:^0.8.1"
+    to-regex: "npm:^3.0.2"
+  checksum: 18d92d9dfe9e199611786495eae2c99a9234581ca23b143b6dc5a76c0b83ba57719e8388c2c2f074b8b9893b61cdf51f26f077da19ccdca764767204d6b02bc7
+  languageName: node
+  linkType: hard
+
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -5189,19 +11262,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:1.52.0":
+"miller-rabin@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "miller-rabin@npm:4.0.1"
+  dependencies:
+    bn.js: "npm:^4.0.0"
+    brorand: "npm:^1.0.1"
+  bin:
+    miller-rabin: bin/miller-rabin
+  checksum: 7a96be873d88380a65170df45121a8da0e96f6a757793a5973cc5161000cdaae1485b06b68375d79a3334c11f985d0734bb8554003fea739371ce2433abba34a
+  languageName: node
+  linkType: hard
+
+"mime-db@npm:1.52.0, mime-db@npm:>= 1.43.0 < 2":
   version: 1.52.0
   resolution: "mime-db@npm:1.52.0"
   checksum: 95baf687a3f14ff2cc433e30dea5c4931c7f4b67059d44a0098cfb833858cad63ec13c20f98762bddd088c4e9dac6d95862db1ea9d3fe3fa68f57b69a325000d
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 51e3b38d1b1b83da082f7c29042bcb22036101346394696b7643ef5da27ebf6bf71643bd45225ee75e4ea2836213780efc8c3dcd2055c84b49eb0afc061419d0
+  languageName: node
+  linkType: hard
+
+"mime@npm:1.6.0":
+  version: 1.6.0
+  resolution: "mime@npm:1.6.0"
+  bin:
+    mime: cli.js
+  checksum: d54c5e4de47046306425767290edaaefc6964fec09960c7df4a1f429f672b6651a13b01724180c698a0f5f0af556a81494d0380404a23da29460716f8454d6e0
+  languageName: node
+  linkType: hard
+
+"mime@npm:^2.4.4":
+  version: 2.6.0
+  resolution: "mime@npm:2.6.0"
+  bin:
+    mime: cli.js
+  checksum: 70c0ce8225abd5593f4c0e77a9d0e7cc50cf526c5c11879897421a697f137a23584d6fb9a2c8f900e70159b7ba961af48a0f467582d5040e00ec49b3c32e920c
   languageName: node
   linkType: hard
 
@@ -5219,6 +11322,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"min-document@npm:^2.19.0":
+  version: 2.19.0
+  resolution: "min-document@npm:2.19.0"
+  dependencies:
+    dom-walk: "npm:^0.1.0"
+  checksum: f4c8fad5f2f11b7b1ed1c8c4c68421d67280b8e3d2fc6799e8f52ada5980e2723c9b55453e9d0610a83a938814f01a5dfa6e4455dccbb53df9f28db90750228d
+  languageName: node
+  linkType: hard
+
 "min-indent@npm:^1.0.0, min-indent@npm:^1.0.1":
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
@@ -5226,7 +11338,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-assert@npm:1.0.1"
+  checksum: e2310081d82a7f8a6ee7f338d167c82b3eb5378929b9eda3a9eb633cf0f0f19c029b69e6868264447d4f726644b52fdc4dda3bc985793a1aeba9b02b13ca3f8e
+  languageName: node
+  linkType: hard
+
+"minimalistic-crypto-utils@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-crypto-utils@npm:1.0.1"
+  checksum: 7d909decd241bd658f941981ce53db4061c834daba807a5082d08fd2a0c488b8ef67904c90af38b70445e0220951a533ae3a181be5724ad342df4d9454286476
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -5255,7 +11381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.6":
+"minimist@npm:^1.1.3, minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"
   checksum: b0286df020a110fa0173e71d8c9903748eb2cc939396d04a61bc224635393c564bc264d04a16e36d51e5489be513f98d7dbe5c2cf11598da11c91f6a18b9449e
@@ -5295,7 +11421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-pipeline@npm:^1.2.4":
+"minipass-pipeline@npm:^1.2.2, minipass-pipeline@npm:^1.2.4":
   version: 1.2.4
   resolution: "minipass-pipeline@npm:1.2.4"
   dependencies:
@@ -5329,6 +11455,45 @@ __metadata:
     minipass: "npm:^3.0.0"
     yallist: "npm:^4.0.0"
   checksum: c0071edb242d6808652840614193316e82d012b79ff1997352de3df1c19b7580d3d4790c462c8506b1f4225f08162ebba88ebceb1529d168304b06b23757e88d
+  languageName: node
+  linkType: hard
+
+"mississippi@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mississippi@npm:3.0.0"
+  dependencies:
+    concat-stream: "npm:^1.5.0"
+    duplexify: "npm:^3.4.2"
+    end-of-stream: "npm:^1.1.0"
+    flush-write-stream: "npm:^1.0.0"
+    from2: "npm:^2.1.0"
+    parallel-transform: "npm:^1.1.0"
+    pump: "npm:^3.0.0"
+    pumpify: "npm:^1.3.3"
+    stream-each: "npm:^1.1.0"
+    through2: "npm:^2.0.0"
+  checksum: be52890333d69a1f0933105c0fa52cff094f7c737364630a51175416f38714fe1b795619d9a4e54c33e1b67ed1938a0578b0d1eb192014e1bc7242035c4ba6a4
+  languageName: node
+  linkType: hard
+
+"mixin-deep@npm:^1.2.0":
+  version: 1.3.2
+  resolution: "mixin-deep@npm:1.3.2"
+  dependencies:
+    for-in: "npm:^1.0.2"
+    is-extendable: "npm:^1.0.1"
+  checksum: 22273c9e1f5d6928d9eb2d2fd4408638a9d8efd3dabb57a3b486b3d21861017eb0ff2b7e9cd4f6351f2ccca7a89a4e7ca1b9059bd714b053236fa8e07b18c844
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^0.5.1, mkdirp@npm:^0.5.3":
+  version: 0.5.6
+  resolution: "mkdirp@npm:0.5.6"
+  dependencies:
+    minimist: "npm:^1.2.6"
+  bin:
+    mkdirp: bin/cmd.js
+  checksum: 8d9642f5caa481eaf1ec556a101c6a5b1528fa20067afd92115d053dc17043efc52c9b77ade0c0115bca4ebb74169e84cacc7f6004db3d1bd4171e131d512cc5
   languageName: node
   linkType: hard
 
@@ -5406,6 +11571,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"move-concurrently@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "move-concurrently@npm:1.0.1"
+  dependencies:
+    aproba: "npm:^1.1.1"
+    copy-concurrently: "npm:^1.0.0"
+    fs-write-stream-atomic: "npm:^1.0.8"
+    mkdirp: "npm:^0.5.1"
+    rimraf: "npm:^2.5.4"
+    run-queue: "npm:^1.0.3"
+  checksum: 23c3a668151ea17debb9dfe4ed33846a5346003372e2a52eafb05a0a493ff9311bd10ee84acb583cc000f7fc2d9a1ebe68db3a54f5d2fd99c6c98474a01d874a
+  languageName: node
+  linkType: hard
+
 "move-file@npm:^3.0.0":
   version: 3.0.0
   resolution: "move-file@npm:3.0.0"
@@ -5436,6 +11615,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ms@npm:2.1.1":
+  version: 2.1.1
+  resolution: "ms@npm:2.1.1"
+  checksum: e7a6b8c7bf8ac18752c9be448fdc6560c429ee2b7593b9c097ba0c1b82b5734ef4735ae853d3ef6663712a39b1cddefd338354838311d35fa87d263de660e0ce
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.1.2":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
@@ -5443,7 +11629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.0.0":
+"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 78c12f6b473a022ebacc393fc14b76fe40b8feda7218124b86c4684e440e10377a063bec1d3902df1f74714f02b74b36ad7d3a6de9e2fbffa26fc29e5ce018fc
@@ -5457,12 +11643,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4":
+"nan@npm:^2.12.1":
+  version: 2.16.0
+  resolution: "nan@npm:2.16.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: ab398d28e1d13f345b932595c43da17487282c15a0bec842cc0668ae54d64e85cc9940405b7d29468a1f31b54d8b679f614dab1e850233f704cdd26a1ae17f03
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.1, nanoid@npm:^3.3.4":
   version: 3.3.4
   resolution: "nanoid@npm:3.3.4"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 53d605377c76614170df4b5a8d3fa21f13c7077453a77e2393a9fe3df5722022f6b94a671f406b51f81e9c937a6928555c1589e3c46a0d9d29f31872d1362246
+  languageName: node
+  linkType: hard
+
+"nanomatch@npm:^1.2.9":
+  version: 1.2.13
+  resolution: "nanomatch@npm:1.2.13"
+  dependencies:
+    arr-diff: "npm:^4.0.0"
+    array-unique: "npm:^0.3.2"
+    define-property: "npm:^2.0.2"
+    extend-shallow: "npm:^3.0.2"
+    fragment-cache: "npm:^0.2.1"
+    is-windows: "npm:^1.0.2"
+    kind-of: "npm:^6.0.2"
+    object.pick: "npm:^1.3.0"
+    regex-not: "npm:^1.0.0"
+    snapdragon: "npm:^0.8.1"
+    to-regex: "npm:^3.0.1"
+  checksum: 79de81312ba5ecf18c35f64a7c22c829d4079c7be275e2e047a6f8372a5d40b95b85eae4e14129d319dba99ae8ab4aedb7308e22bdf3ab521b25154233bd6253
   languageName: node
   linkType: hard
 
@@ -5473,14 +11687,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"negotiator@npm:^0.6.3":
+"negotiator@npm:0.6.3, negotiator@npm:^0.6.3":
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: d8e3b42d99638b1f363ce114c98e6906ade395c230058e50644417bd398b01381133dbca4bc49f30f6b1c93254e4b5a2d50cc47adcdabf2a8476b6f16311ad5d
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.7":
+"neo-async@npm:^2.5.0, neo-async@npm:^2.6.0, neo-async@npm:^2.6.1, neo-async@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "neo-async@npm:2.6.2"
+  checksum: 968ceb7350efb069a413eaa590b9ec2532023d6f4075c06ada75a57f86ff7ffbfc5b0b72760fadc1ccdc546b9c0bc346b69e9f5b03cdaa42f21e8063b880d305
+  languageName: node
+  linkType: hard
+
+"nested-error-stacks@npm:^2.0.0, nested-error-stacks@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "nested-error-stacks@npm:2.1.1"
+  checksum: 9046e33acd3c96356fde0cf7aae9518ea591ea4c08e6d66aa3f7fe759bfb853c96150b2d1c6782bffc007110952f34ea5cdabd996e84abcc201e91e821fc9058
+  languageName: node
+  linkType: hard
+
+"no-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "no-case@npm:3.0.4"
+  dependencies:
+    lower-case: "npm:^2.0.2"
+    tslib: "npm:^2.0.3"
+  checksum: 862a2115a3eb27b2293be320faf1408cb0ee75a1da41a463463f53bfeb34f20c89805279fc2c6123b79c3d366f9e445cfcb8e0582611e2bd6712fa8edfaabbda
+  languageName: node
+  linkType: hard
+
+"node-dir@npm:^0.1.10":
+  version: 0.1.17
+  resolution: "node-dir@npm:0.1.17"
+  dependencies:
+    minimatch: "npm:^3.0.2"
+  checksum: 50640060446acb8b08023f6bf242524392e8f41d49dba522493cff538b39a3b6a269085ccb37e20d3c88d343c4cf4e5ef7901bd85d533caacc9f7bb8d41f698d
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -5511,6 +11758,37 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 7cfa4c7843c37a68ab2123ffbab5f269cc2d36e697c37154566b701b1fe3bfd861260e0e00530a720ae1a2a92589fa19b85565e36bdcb8a4683a4a4e207338b6
+  languageName: node
+  linkType: hard
+
+"node-libs-browser@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "node-libs-browser@npm:2.2.1"
+  dependencies:
+    assert: "npm:^1.1.1"
+    browserify-zlib: "npm:^0.2.0"
+    buffer: "npm:^4.3.0"
+    console-browserify: "npm:^1.1.0"
+    constants-browserify: "npm:^1.0.0"
+    crypto-browserify: "npm:^3.11.0"
+    domain-browser: "npm:^1.1.1"
+    events: "npm:^3.0.0"
+    https-browserify: "npm:^1.0.0"
+    os-browserify: "npm:^0.3.0"
+    path-browserify: "npm:0.0.1"
+    process: "npm:^0.11.10"
+    punycode: "npm:^1.2.4"
+    querystring-es3: "npm:^0.2.0"
+    readable-stream: "npm:^2.3.3"
+    stream-browserify: "npm:^2.0.1"
+    stream-http: "npm:^2.7.2"
+    string_decoder: "npm:^1.0.0"
+    timers-browserify: "npm:^2.0.4"
+    tty-browserify: "npm:0.0.0"
+    url: "npm:^0.11.0"
+    util: "npm:^0.11.0"
+    vm-browserify: "npm:^1.0.1"
+  checksum: 2bcc8dd7e96bdbd86471c1355e073741fae619030e8175befb52c0d5bac3470b02a2bf94bf36dc4fd9dd8ff79ccd1889b58154aed7db17063be040d360fe91ab
   languageName: node
   linkType: hard
 
@@ -5546,7 +11824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.5.0":
+"normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.3.4, normalize-package-data@npm:^2.5.0":
   version: 2.5.0
   resolution: "normalize-package-data@npm:2.5.0"
   dependencies:
@@ -5570,10 +11848,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-path@npm:^3.0.0":
+"normalize-path@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "normalize-path@npm:2.1.1"
+  dependencies:
+    remove-trailing-separator: "npm:^1.0.1"
+  checksum: 0987d81d5f731b480b60ba650be3217a996118807beb33b63272e40ad8b86bdbe6cb73d760038a57c20dbf299ff979da49ec3b15a39fe2c48f48f36baac4c9c7
+  languageName: node
+  linkType: hard
+
+"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 66de83885051c8a7266566cb175281ec583e3d66b5054c744b46a0eebc4eaac1e1d74c640aaf72144086a9661aa60e89ac0b5c92eb76608e5b8a5056dbcf9e27
+  languageName: node
+  linkType: hard
+
+"normalize-range@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "normalize-range@npm:0.1.2"
+  checksum: 6f4b792ccc8a0c23cbbe983d79f25b2005872e7b7a62f153abeb8dd5aebe445e52ac1b33376e22f0937f31b78e37b8bd440dc08fc73aa0ba292f47bbc980e450
   languageName: node
   linkType: hard
 
@@ -5604,6 +11898,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npmlog@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "npmlog@npm:5.0.1"
+  dependencies:
+    are-we-there-yet: "npm:^2.0.0"
+    console-control-strings: "npm:^1.1.0"
+    gauge: "npm:^3.0.0"
+    set-blocking: "npm:^2.0.0"
+  checksum: 3a7127689c165c3e2f7df33eb0c01b82e6ff5cb9ea2d15091b5cd7a981d8a0ffc7221ad3f2f0ee934d7ac18f6ac3b6fd0984eb17f9ffd2dfbd15af409bc5c6d7
+  languageName: node
+  linkType: hard
+
 "npmlog@npm:^6.0.0":
   version: 6.0.2
   resolution: "npmlog@npm:6.0.2"
@@ -5616,10 +11922,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4.1.1":
+"nth-check@npm:^2.0.1":
+  version: 2.1.1
+  resolution: "nth-check@npm:2.1.1"
+  dependencies:
+    boolbase: "npm:^1.0.0"
+  checksum: 47e3a752fb9e7619e0567ce3bf5a38b766689d94be7cfa10099688d1f521cfb9698a6f7ef032d608a24bbbd1e412748929940170c5e6db433326ad1471031143
+  languageName: node
+  linkType: hard
+
+"num2fraction@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "num2fraction@npm:1.2.2"
+  checksum: a0305841e53478edfbc05b2d49329dd441999f0617f7dcaabc2090a18f5e7ec2062f93997c908eacd06c3368967dde2a75645c4377e1130e1b9dd185cc77a603
+  languageName: node
+  linkType: hard
+
+"object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: f5cd1f2f1e82e12207e4f2377d9d7d90fbc0d9822a6afa717a6dcab6930d8925e1ebbbb25df770c31ff11335ee423459ba65ffa2e53999926c328b806b4d73d6
+  languageName: node
+  linkType: hard
+
+"object-copy@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "object-copy@npm:0.1.0"
+  dependencies:
+    copy-descriptor: "npm:^0.1.0"
+    define-property: "npm:^0.2.5"
+    kind-of: "npm:^3.0.3"
+  checksum: df2c44552d01b270c5b95339a3d935709d9657c1c32e551d804b88477a2cf68e01ce5c6f9364cc939e2aaa24d629fec35e939da0f1dc6739e3ee7e170d85766e
   languageName: node
   linkType: hard
 
@@ -5637,7 +11970,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.2":
+"object-visit@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "object-visit@npm:1.0.1"
+  dependencies:
+    isobject: "npm:^3.0.0"
+  checksum: 0e76d72cbe2abf8b5eb4438afe89aaea979f28bbc43dac86ddcf19b3acb092469068f8f93841e404fcc79e4bf89b8d2b0af09361967645f429417c0b7221ed9b
+  languageName: node
+  linkType: hard
+
+"object.assign@npm:^4.1.0, object.assign@npm:^4.1.2":
   version: 4.1.2
   resolution: "object.assign@npm:4.1.2"
   dependencies:
@@ -5649,7 +11991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.5":
+"object.entries@npm:^1.1.0, object.entries@npm:^1.1.5":
   version: 1.1.5
   resolution: "object.entries@npm:1.1.5"
   dependencies:
@@ -5660,7 +12002,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.fromentries@npm:^2.0.5":
+"object.fromentries@npm:^2.0.0 || ^1.0.0, object.fromentries@npm:^2.0.5":
   version: 2.0.5
   resolution: "object.fromentries@npm:2.0.5"
   dependencies:
@@ -5668,6 +12010,18 @@ __metadata:
     define-properties: "npm:^1.1.3"
     es-abstract: "npm:^1.19.1"
   checksum: 082cd286b0cf074daadbdd5b5c780f294c19ac061993fa415ff126440cea74d15c68fe3ab1b60a67ab1a6d1338fcae706470071171fa36aef4820fafc7530c5c
+  languageName: node
+  linkType: hard
+
+"object.getownpropertydescriptors@npm:^2.0.3, object.getownpropertydescriptors@npm:^2.1.2":
+  version: 2.1.4
+  resolution: "object.getownpropertydescriptors@npm:2.1.4"
+  dependencies:
+    array.prototype.reduce: "npm:^1.0.4"
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.4"
+    es-abstract: "npm:^1.20.1"
+  checksum: 0191753437229bfae7bdbb03f5d56d1f7befea9d4b12a6d1b5392a9d1c0d40d78334c6bf3ddbfd7e89d9f3ced6388d6a033dfb32c012b467aee9113e94ea64d6
   languageName: node
   linkType: hard
 
@@ -5681,7 +12035,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.5":
+"object.pick@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "object.pick@npm:1.3.0"
+  dependencies:
+    isobject: "npm:^3.0.1"
+  checksum: d276c0d9447ab48a1639595dd770a91d914a37312814c9a391ecc214e716d78013dcf4ae7d06df6cc5ad96cfee45da2b04318c0f09ce414a2927f69cd84b6a0f
+  languageName: node
+  linkType: hard
+
+"object.values@npm:^1.1.0, object.values@npm:^1.1.5":
   version: 1.1.5
   resolution: "object.values@npm:1.1.5"
   dependencies:
@@ -5692,12 +12055,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:~2.3.0":
-  version: 2.3.0
-  resolution: "on-finished@npm:2.3.0"
+"objectorarray@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "objectorarray@npm:1.0.5"
+  checksum: 447bf4acce3d0c26735089b5b23a41b5b66b2b1f590f3192a13dbf84f256a5c440b06c260b3ae9b4857fd5d3003a3d7972e7e22410e473fdf875bd33e167c674
+  languageName: node
+  linkType: hard
+
+"on-finished@npm:2.4.1":
+  version: 2.4.1
+  resolution: "on-finished@npm:2.4.1"
   dependencies:
     ee-first: "npm:1.1.1"
-  checksum: 44e294ed88a954e3eba9dd56964a387f1a217cb518cb1f60644eb942ae1fd2be37bdde46b9b212c2de5fd5c9df23e382ce2b16f5635c00845aaf21344389c0b3
+  checksum: 93ad68cf985df7d5263acef0302610a63f5d28840054b8d9a085776427beec4c7ce5518274c46b302eefd43747e81f6bb7df7dc4a2a2b345c0c49f31ad344385
+  languageName: node
+  linkType: hard
+
+"on-headers@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "on-headers@npm:1.0.2"
+  checksum: 218d6cc0332f79a0c07ba5f0dba44cfead4bea1473426b7881628a36d69aed74722734856bebb05b29588e903cd40f1a2d0a917c1f6866a752e5340270c33b84
   languageName: node
   linkType: hard
 
@@ -5728,6 +12105,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"open@npm:^7.0.3":
+  version: 7.4.2
+  resolution: "open@npm:7.4.2"
+  dependencies:
+    is-docker: "npm:^2.0.0"
+    is-wsl: "npm:^2.1.1"
+  checksum: b3619842c6ecee8dd4d6010066757e968223678f39cfbaa57c06aa1cb133383f86238b4d3071e5bb693f2526cb67e89eef0e9e6e355964ddbbcf78404853f888
+  languageName: node
+  linkType: hard
+
+"open@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "open@npm:8.4.0"
+  dependencies:
+    define-lazy-prop: "npm:^2.0.0"
+    is-docker: "npm:^2.1.1"
+    is-wsl: "npm:^2.2.0"
+  checksum: 287db1bc10b3927b247d7c125d3ef998c410f57f434619a9d93f3e1384ff025ef12c18c1cfde1cb8f23f1326fb2bfe2634c789737bb65c18183015b5de81f594
+  languageName: node
+  linkType: hard
+
+"optionator@npm:^0.8.1":
+  version: 0.8.3
+  resolution: "optionator@npm:0.8.3"
+  dependencies:
+    deep-is: "npm:~0.1.3"
+    fast-levenshtein: "npm:~2.0.6"
+    levn: "npm:~0.3.0"
+    prelude-ls: "npm:~1.1.2"
+    type-check: "npm:~0.3.2"
+    word-wrap: "npm:~1.2.3"
+  checksum: 021c16397799d38097056ba4ed2469ba10c873ebcae4cf231a87f7197ab44bbb028a5e90d4b82c5709c56463957e394cdfa39efb2e6c1215a0b770eccbc6dfe0
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.9.1":
   version: 0.9.1
   resolution: "optionator@npm:0.9.1"
@@ -5742,10 +12154,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"os-browserify@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "os-browserify@npm:0.3.0"
+  checksum: 7186372ce3ed1c51bea1dd6a01fecb40be4acb1a164d00bd86cb86f983aaf5821c1a9fea95e783e096d77d3d22f44bc0742dada27c043f43e36314491f725976
+  languageName: node
+  linkType: hard
+
 "os-homedir@npm:^1.0.0":
   version: 1.0.2
   resolution: "os-homedir@npm:1.0.2"
   checksum: a9952fc2f0428609088f9be0b399c7029ef090c9a9d065c5cfa1c41b25a7d441df98f19368d2cc7c19c7e932759b918fe9e6cb7ee61b1343341a42f2481ab6ca
+  languageName: node
+  linkType: hard
+
+"p-all@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "p-all@npm:2.1.0"
+  dependencies:
+    p-map: "npm:^2.0.0"
+  checksum: 29716fa83d0c33aa94e760f41c62d0fdd6596e8f81eb47ef5da0c1499d91218d3a23787f816aa9610826382d5ab75b490a32676f57115a36b92b4a7a098f237d
+  languageName: node
+  linkType: hard
+
+"p-event@npm:^4.1.0":
+  version: 4.2.0
+  resolution: "p-event@npm:4.2.0"
+  dependencies:
+    p-timeout: "npm:^3.1.0"
+  checksum: d84171a48889b0ed09ab55e368f20eb690343ee1910a26901d79179bc6e47e85d66d0700b7ae0be8d7d719e9380b77c7a19711a5f254d22887ab8ade56fdf1eb
+  languageName: node
+  linkType: hard
+
+"p-filter@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "p-filter@npm:2.1.0"
+  dependencies:
+    p-map: "npm:^2.0.0"
+  checksum: fdc599577663ba96d379220155404e94c9cbf102a0e156d3170e3b0347a9f5546d282ee17ed5e6ad8b9beab98f0bbbc7008023da3a357355abea3da1b7692c7e
+  languageName: node
+  linkType: hard
+
+"p-finally@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "p-finally@npm:1.0.0"
+  checksum: e3452db75cacc60e8b834a905e38f3cd9dc21e76e471efcde8a36ea04ec6fc507f6b5f74cbd7252d8c9317846127084831f89318e476ca0023d4ab223f3e146b
   languageName: node
   linkType: hard
 
@@ -5756,7 +12209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^2.2.0":
+"p-limit@npm:^2.0.0, p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
   dependencies:
@@ -5771,6 +12224,15 @@ __metadata:
   dependencies:
     yocto-queue: "npm:^0.1.0"
   checksum: c38ea177d6bd9e8b9a8c296145bfe2aa8963f6aae5c864630a4e1728513953319ab13bc113fe00e2b632e0ec039b23daa311f79b4f7f04b0b50f2d8b994fad46
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "p-locate@npm:3.0.0"
+  dependencies:
+    p-limit: "npm:^2.0.0"
+  checksum: b54aaaebb15cc2d854752e424d73f9626aefdc5700821836a247f41039b668ebfa9e702e672adc79643ecdb7518fce92d0d721ea59754afcef32681aab4a732d
   languageName: node
   linkType: hard
 
@@ -5792,6 +12254,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-map@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "p-map@npm:2.1.0"
+  checksum: a55add9a8c3790e056d467d784d9b2c0ccf7b2ef0257447c2a6920d03bca4aded1f59343886a87afb042f4993f93f91d16569dd3bc91c5d668e55f7c997079b8
+  languageName: node
+  linkType: hard
+
+"p-map@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "p-map@npm:3.0.0"
+  dependencies:
+    aggregate-error: "npm:^3.0.0"
+  checksum: 1e12503ad0796913c8b2949f02873085270a0641d1c398d1d2e6c62bd47f39bbd87b77c82f4bae8293aff91eaeadfee1ec98a2e5d21e21ab242f1a2508b98362
+  languageName: node
+  linkType: hard
+
 "p-map@npm:^4.0.0":
   version: 4.0.0
   resolution: "p-map@npm:4.0.0"
@@ -5810,10 +12288,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-timeout@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "p-timeout@npm:3.2.0"
+  dependencies:
+    p-finally: "npm:^1.0.0"
+  checksum: 350fc15deef1aede66e4dc81b4ed92a0383108162b2528253850d1cf28f2e6847d4834c03bdc7e7143d106e569936495751ba52a521a82476b346cdd748293d3
+  languageName: node
+  linkType: hard
+
 "p-try@npm:^2.0.0":
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: 1b9a6b5d6f42a46e36f053ee737a72cbe8f7990ee65e0d7bc3f8f8324e233d5b5e790f9f660bcc44d93738a2b12108dec1f7a39c9650d276fd1f9d73d54d4f55
+  languageName: node
+  linkType: hard
+
+"pako@npm:~1.0.5":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 72a95941f553d177fc7f01302f541d379015280e20eeddff28c2b503f3c25353ce18eaf280e9343c548a764a81c3a5f093c6ed84cc951bc0472141f655a9b0b7
+  languageName: node
+  linkType: hard
+
+"parallel-transform@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "parallel-transform@npm:1.2.0"
+  dependencies:
+    cyclist: "npm:^1.0.1"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^2.1.5"
+  checksum: 0d88d2adf897dd678d9027ef7a8304c0195ca5073ea8e0a32f0e219d2e7dcda2b1efc3ca77a55aae0bdafe004772f33190543c3e625aa44fe37acae0cff2a8b8
+  languageName: node
+  linkType: hard
+
+"param-case@npm:^3.0.3":
+  version: 3.0.4
+  resolution: "param-case@npm:3.0.4"
+  dependencies:
+    dot-case: "npm:^3.0.4"
+    tslib: "npm:^2.0.3"
+  checksum: eab62423d2e4fafd0f6dc54d3639dda7a6437bf084d16549bf4df62a7cb972b588cd01ed47511d4fae2165e87f510396edd0fa32935e61d8bc984319a839a9ff
   languageName: node
   linkType: hard
 
@@ -5835,6 +12350,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-asn1@npm:^5.0.0, parse-asn1@npm:^5.1.5":
+  version: 5.1.6
+  resolution: "parse-asn1@npm:5.1.6"
+  dependencies:
+    asn1.js: "npm:^5.2.0"
+    browserify-aes: "npm:^1.0.0"
+    evp_bytestokey: "npm:^1.0.0"
+    pbkdf2: "npm:^3.0.3"
+    safe-buffer: "npm:^5.1.1"
+  checksum: 0c7c7cd35d6e59dd79f647430ed46a19f9dbf771595fd98605ffc210d6b01bdf1d020a9ef2f84c74c7d17c3466a00ff414fea4ce05306f1d9494051f6a0d9c6d
+  languageName: node
+  linkType: hard
+
 "parse-entities@npm:^2.0.0":
   version: 2.0.0
   resolution: "parse-entities@npm:2.0.0"
@@ -5846,6 +12374,15 @@ __metadata:
     is-decimal: "npm:^1.0.0"
     is-hexadecimal: "npm:^1.0.0"
   checksum: bd533cb17d31bde3c04b264e3a58c96132cab6f3becb3d955cf9b74b4928c244e90ada48f09f4d1aef0576d0011d1e6b106667bef427b543166d856a4ad3b2c1
+  languageName: node
+  linkType: hard
+
+"parse-json@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "parse-json@npm:2.2.0"
+  dependencies:
+    error-ex: "npm:^1.2.0"
+  checksum: 1e59757ae711945d654f9ae36bfe613ed5f15895c2cf3829d3243e846a435549facda57ced14085fa3276530bd9c796206f3b9f1a1171c0d33deacb8093f5dde
   languageName: node
   linkType: hard
 
@@ -5861,10 +12398,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parseurl@npm:~1.3.3":
+"parse5@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "parse5@npm:6.0.1"
+  checksum: fc646cd35285973de9322a034872c145bb8c07559bd0fa46e9c133567978622f3fe3977794b6e31089b3b6692284b2a3b8fb3fc547b9b21ef059fd20cac72982
+  languageName: node
+  linkType: hard
+
+"parseurl@npm:~1.3.2, parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: cbd2f45d9ab7fe80e5a742ff88fdedcfae00a32b1e6cca174c4d5c11b9480d0dde9a22b5e9505da44734f047e7cea8457508fced54067b870595a7938d29b467
+  languageName: node
+  linkType: hard
+
+"pascal-case@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "pascal-case@npm:3.1.2"
+  dependencies:
+    no-case: "npm:^3.0.4"
+    tslib: "npm:^2.0.3"
+  checksum: 1d34b5460567fdbdb0d028bb95faaf10e7eeaa4c013922d2654bea50ce75f51a6e42b502d3257de5136ec8b80eebc395a8d2dda466d452b472a3ced16073567a
+  languageName: node
+  linkType: hard
+
+"pascalcase@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "pascalcase@npm:0.1.1"
+  checksum: d6743b6f283eecb497b512cb7b2205a49819324aacf61b3b81e9fc2aabf1ec57ca73a156328257458265f4a2e9cb798ddd048979a5a6333984769bddf00e4b6d
+  languageName: node
+  linkType: hard
+
+"path-browserify@npm:0.0.1":
+  version: 0.0.1
+  resolution: "path-browserify@npm:0.0.1"
+  checksum: 1be4c6604998b10452e2b962df85d6ffb0b7a95e42b0c37c62da0cfff5679cc901a7e9d941ee487aabafc021c52097914944719c0e38924183f767059c7dce4c
+  languageName: node
+  linkType: hard
+
+"path-dirname@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "path-dirname@npm:1.0.2"
+  checksum: 3a1df8562a47f67e25407e6f6d8b022c474d69e9801898ffaa861af727c26c352afaaef5b01642d92f900b35c438c5eaa5101d5c274b6171b62aaa4c9ccc8deb
+  languageName: node
+  linkType: hard
+
+"path-exists@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "path-exists@npm:2.1.0"
+  dependencies:
+    pinkie-promise: "npm:^2.0.0"
+  checksum: 332952a80f3bc4186fa28c40b0f317b287956516b35ffc0ce4be8856ad4adc6dbf9078e51a47d3b8d5cdb55aa2b5d10f181bdc483ead29a88e69673a064c7aa8
+  languageName: node
+  linkType: hard
+
+"path-exists@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-exists@npm:3.0.0"
+  checksum: 6479d25601e17c2dbe1a02b3f00fe62416f3c8909ab7352f4f492bdc781ed745d8d0ef03fe233c20323a44fac38b3a6c3cc6865b7d0c68635fdff9e2abf7304c
   languageName: node
   linkType: hard
 
@@ -5910,6 +12501,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:0.1.7":
+  version: 0.1.7
+  resolution: "path-to-regexp@npm:0.1.7"
+  checksum: 65caab5a929dda7ae7f6ab3be871a82390317291271694dea898eea5fdcc232ae7fd197a76a3cda4bd6dcef8d82e582578e02eb7d5fa659df0f4d33a53c9753f
+  languageName: node
+  linkType: hard
+
+"path-type@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "path-type@npm:1.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.2"
+    pify: "npm:^2.0.0"
+    pinkie-promise: "npm:^2.0.0"
+  checksum: eea7038f829ebf7df08ac8008fd7fd53e505c0916c7fed61a138a56fcd6b73e53b288a067d2a47f5bfc06667aa0c3501b5af7d217114ccd5b35eaf2cc74501d9
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-type@npm:3.0.0"
@@ -5947,6 +12556,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pbkdf2@npm:^3.0.3":
+  version: 3.1.2
+  resolution: "pbkdf2@npm:3.1.2"
+  dependencies:
+    create-hash: "npm:^1.1.2"
+    create-hmac: "npm:^1.1.4"
+    ripemd160: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+    sha.js: "npm:^2.4.8"
+  checksum: 5b5e46c0e65c2041f7b2bab88f1eb1132f9f326efdb7e80866e28428e24f979a1b901a695d17ac02ae72ec36e66f6b61a4e9a3878cb106bcef53dd32aee1cc6d
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "picocolors@npm:0.2.1"
+  checksum: 13a46f38c986460662da0122e63318cb93c043dea5daf7bc98a8615e4d90c78aae20e70e76a4558327127c5a8014450020ba8ef243f9af757788f3937e3615fd
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
@@ -5954,7 +12583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.2.2, picomatch@npm:^2.3.1":
+"picomatch@npm:2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 6ba5938c24af2c5918e94b39aa0ad48d71f2c30634de69d46e0bd32feb666de4e909406db6ffb78f98d39ef450d6a41b6fa3954dc3659d7b2b750766c1261e5e
@@ -5970,7 +12599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pify@npm:^2.3.0":
+"pify@npm:^2.0.0, pify@npm:^2.3.0":
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
   checksum: 9a3b2aa18d26ed79db45dee98f52675750ad11ced96b45b4884f4d4368217046137e35481146bfc94698f5709fd838d86f1d2d80d958f5f88767e426d29cbc66
@@ -5984,7 +12613,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pinkie-promise@npm:^2.0.1":
+"pify@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "pify@npm:4.0.1"
+  checksum: 53d52fa909026494c83009816cbfe420f014b4ebafaa0f1b702cb03172e7e72cf14678cf6b545d3d722c88bc4717ccf4dc5b79bdf689d5e1776cf795659da49b
+  languageName: node
+  linkType: hard
+
+"pinkie-promise@npm:^2.0.0, pinkie-promise@npm:^2.0.1":
   version: 2.0.1
   resolution: "pinkie-promise@npm:2.0.1"
   dependencies:
@@ -5997,6 +12633,40 @@ __metadata:
   version: 2.0.4
   resolution: "pinkie@npm:2.0.4"
   checksum: 1bc1eb7aab96ec9674e0614146ad0b7ad9856d840140de3268d7900cc0259640ca17353708261659584e3f954b8ad8b39a4245dc5def50fcf7f4ddb09d3d7d20
+  languageName: node
+  linkType: hard
+
+"pirates@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "pirates@npm:4.0.5"
+  checksum: 1ade661dec736ffce6976c3430d37412bb75d7ba7caeb36ce3142de9b8bea4f756f0b317a2a24a28dd9e84adbf7a7819bfdca719126ccc44bf27b62d4a880eda
+  languageName: node
+  linkType: hard
+
+"pkg-dir@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pkg-dir@npm:3.0.0"
+  dependencies:
+    find-up: "npm:^3.0.0"
+  checksum: 62d92804c4cb87391246c494bfe2b9cb8a4fcb9a7e6906676254939b4cfb5e3fcbbf1bd5374c8d122f8f515d803116a861af70aacda2823c6b714c7d0096a7f1
+  languageName: node
+  linkType: hard
+
+"pkg-dir@npm:^4.1.0":
+  version: 4.2.0
+  resolution: "pkg-dir@npm:4.2.0"
+  dependencies:
+    find-up: "npm:^4.0.0"
+  checksum: 220ae78b93ef48d6cd81958ff3bdda5f5e6268c9887ca430aa974370499669c72886d85db0a768898a0a09114be14aab9a7171356033c082c0d2e65f384a5886
+  languageName: node
+  linkType: hard
+
+"pkg-dir@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "pkg-dir@npm:5.0.0"
+  dependencies:
+    find-up: "npm:^5.0.0"
+  checksum: cd67fb907e216bfca98c8c2c1ca434b2722e950201e6262b19b70c18268ee5bf2dde64366b3b51a626e28e2f193da41643d6fdcc210c8a0961fc351faa9259c8
   languageName: node
   linkType: hard
 
@@ -6018,7 +12688,116 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.13, postcss@npm:^8.4.14":
+"pnp-webpack-plugin@npm:1.6.4":
+  version: 1.6.4
+  resolution: "pnp-webpack-plugin@npm:1.6.4"
+  dependencies:
+    ts-pnp: "npm:^1.1.6"
+  checksum: 7c8958fc6e2549e28b02144cd743f6c28b26a5dcc461fa0cbb82a2feedd6eaf5a7c6e9febe370a0adbc7c7c5b6ec04082d96f896e478d42ed05acc6a6a1c3a20
+  languageName: node
+  linkType: hard
+
+"posix-character-classes@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "posix-character-classes@npm:0.1.1"
+  checksum: 14790f421e18d173917b1f91ed156f7afa22e823214998ef73d2f4392f6ecaf68bb179c40677b490ea97494bde47d8355028303a62519cf4c1bca31afcafc783
+  languageName: node
+  linkType: hard
+
+"postcss-flexbugs-fixes@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "postcss-flexbugs-fixes@npm:4.2.1"
+  dependencies:
+    postcss: "npm:^7.0.26"
+  checksum: f17ae3b643d09b775d3350f79b1885c09dd3cabc7b8feb50eb8b5ec01af63178590e52ca0fb19bb856ac7f1a7330c36982bd1deee27177c6d375a12b439ed75a
+  languageName: node
+  linkType: hard
+
+"postcss-loader@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "postcss-loader@npm:4.3.0"
+  dependencies:
+    cosmiconfig: "npm:^7.0.0"
+    klona: "npm:^2.0.4"
+    loader-utils: "npm:^2.0.0"
+    schema-utils: "npm:^3.0.0"
+    semver: "npm:^7.3.4"
+  peerDependencies:
+    postcss: ^7.0.0 || ^8.0.1
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: ba39f9257d1ca12728986783720adb86b604967b546f0d10789c66fedc63405fdf3fd866b938af48c56251dd9fb5fe7bd174f9e44372ac71e68269d7e32117a1
+  languageName: node
+  linkType: hard
+
+"postcss-modules-extract-imports@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "postcss-modules-extract-imports@npm:2.0.0"
+  dependencies:
+    postcss: "npm:^7.0.5"
+  checksum: b410c03e8aec7fd8851861b3323beb5340f44e2c8c6099477d1748b774fbd5ce0e9e341ef5e4d9c3a0d0feb3123c770b9a2a772fb2690bb463d5a55da07ca7a6
+  languageName: node
+  linkType: hard
+
+"postcss-modules-local-by-default@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "postcss-modules-local-by-default@npm:3.0.3"
+  dependencies:
+    icss-utils: "npm:^4.1.1"
+    postcss: "npm:^7.0.32"
+    postcss-selector-parser: "npm:^6.0.2"
+    postcss-value-parser: "npm:^4.1.0"
+  checksum: e25dbe582146e6ede98b87cbc8250d2eed6a06e45e1045ee5b380aa0b9534e88a9cc7f5bf38fa2cc67025baa8c1ac297107317186140ceef03f3dcaa44ff1023
+  languageName: node
+  linkType: hard
+
+"postcss-modules-scope@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "postcss-modules-scope@npm:2.2.0"
+  dependencies:
+    postcss: "npm:^7.0.6"
+    postcss-selector-parser: "npm:^6.0.0"
+  checksum: acdf3478f556014f7d9ffe3cbfff025f3e4792a84c97ee3c6e567c0a39fcafa0563cbced7bc1fefadb70a938075bc315bca9f1513ff24f71dc4e08a8729fa819
+  languageName: node
+  linkType: hard
+
+"postcss-modules-values@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "postcss-modules-values@npm:3.0.0"
+  dependencies:
+    icss-utils: "npm:^4.0.0"
+    postcss: "npm:^7.0.6"
+  checksum: 7026f6b2f20ca6ee89dd70f0fb8c4618cc709d1282b2ebc88e6ac2948257c0b22eb04f8070974acc5cff1f5d6f4d83724011a878e225292ea608f3e6089bc808
+  languageName: node
+  linkType: hard
+
+"postcss-selector-parser@npm:^6.0.0, postcss-selector-parser@npm:^6.0.2":
+  version: 6.0.10
+  resolution: "postcss-selector-parser@npm:6.0.10"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 7ab7cbeba12343c9b8034c556a8e463ec13adbcc891eb8c51bb8f97d65b6bcb5dcd641df7b30014241e3f2435e3f6fbdf3229a8bdd25c14d88df24cb19e8e864
+  languageName: node
+  linkType: hard
+
+"postcss-value-parser@npm:^4.0.2, postcss-value-parser@npm:^4.1.0":
+  version: 4.2.0
+  resolution: "postcss-value-parser@npm:4.2.0"
+  checksum: edc490e9f11336a2efb136d8a52350b5c680ca9a91ee64285732e796177eb888f559a4eafc94cdbf7ce065a388e65b3cc21a32c92458a90efc445f30e8a679dc
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^7.0.14, postcss@npm:^7.0.26, postcss@npm:^7.0.32, postcss@npm:^7.0.36, postcss@npm:^7.0.5, postcss@npm:^7.0.6":
+  version: 7.0.39
+  resolution: "postcss@npm:7.0.39"
+  dependencies:
+    picocolors: "npm:^0.2.1"
+    source-map: "npm:^0.6.1"
+  checksum: 5027f2aac0ee8c9746c4ef0ea31c7ed85153af1c9a2aeafc4950961cbfbaf8a1bbd4494e95556ba1f0f0c4735eb33e95efd9622d7ffbc73911819f24800f10de
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.14":
   version: 8.4.14
   resolution: "postcss@npm:8.4.14"
   dependencies:
@@ -6033,6 +12812,13 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: 0fee0e2ba5dc7793340a5861d9d37ce4f3d8ec246099bfae25e1f2a928a4df1c009a91882c35862bdf245f69081160df4ed0ec2438662ae22e50b621a6b7848f
+  languageName: node
+  linkType: hard
+
+"prelude-ls@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "prelude-ls@npm:1.1.2"
+  checksum: e18c52ae66a3327dc4c51defe91f05505d8df7a4f75ae7cc99d6689a2b84817b57828f09bb3da073ef34af28275dbbaacedc1028e3564e681a67f5f6a0351468
   languageName: node
   linkType: hard
 
@@ -6065,10 +12851,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:>=2.2.1 <=2.3.0":
+  version: 2.3.0
+  resolution: "prettier@npm:2.3.0"
+  bin:
+    prettier: bin-prettier.js
+  checksum: e19269e7fdae5bf115e25b85cdcf11513823243aab1e9119643cbcf161afb48ee9fc52ebbf5bde1468766e39b4c4d78e0b068644cfb2604f17f704cfe3776ac6
+  languageName: node
+  linkType: hard
+
 "pretty-bytes@npm:^6.0.0":
   version: 6.0.0
   resolution: "pretty-bytes@npm:6.0.0"
   checksum: 9033b687324fe83d1a74b2c69637e4eb26693da76010a3446bb24bdec1508106ed930fcfe61a7661a227c32ea2e499b1aa0493fe370c844dfb329e4c7c3ff0ff
+  languageName: node
+  linkType: hard
+
+"pretty-error@npm:^2.1.1":
+  version: 2.1.2
+  resolution: "pretty-error@npm:2.1.2"
+  dependencies:
+    lodash: "npm:^4.17.20"
+    renderkid: "npm:^2.0.4"
+  checksum: 4c637ef9a412cd6577e94d91deaaea0d095599eaa884d488f90742dd5ff7b26429d30544cb5120ebfe0a85044f9c45bab7b87809876a230a53ea6f24932600a7
   languageName: node
   linkType: hard
 
@@ -6081,6 +12886,41 @@ __metadata:
     ansi-styles: "npm:^5.0.0"
     react-is: "npm:^18.0.0"
   checksum: 7ea80c810b87645bfb7a92736ea12588430ded3ec7833d158c438ec1d463c4187abb2ec1bb6efcd99fc6b81c2b786bb4ec7c29eee6f881595b0170fae702448e
+  languageName: node
+  linkType: hard
+
+"pretty-hrtime@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "pretty-hrtime@npm:1.0.3"
+  checksum: 0c7e44c877abaaef41d93231e143d5505d0234376a7074a6ec65dc6809e751398f18949014977f4cce1c9117ae27ecb28d73ed2995bf5fedfb54776d4bd55824
+  languageName: node
+  linkType: hard
+
+"prismjs@npm:^1.27.0":
+  version: 1.28.0
+  resolution: "prismjs@npm:1.28.0"
+  checksum: 5666a3285eec5711e9c70bab61c16bb42151d59f43784910cdcfa91baf444957f7fbe0156c8c376a4ebefe929ab76d677263afe5bde67bb4418ec553bd91c2af
+  languageName: node
+  linkType: hard
+
+"prismjs@npm:~1.27.0":
+  version: 1.27.0
+  resolution: "prismjs@npm:1.27.0"
+  checksum: 9df57515e05ae5a79083c4110815e4730ff7c2fe80797ced4a407ee9a8d168d056538566cb830fe5effb8ab1139978d4e999421dbcfae64348d4f30e0ef3576e
+  languageName: node
+  linkType: hard
+
+"process-nextick-args@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "process-nextick-args@npm:2.0.1"
+  checksum: 09ec0ec8e28a923bdf8d0b926bfbba475553de2cf0be9232d76904a21a3c8c03b6dd4625738ee0bab8fa10b9b2f2fda8a3f9d18815c3407c30f13b51f84605e9
+  languageName: node
+  linkType: hard
+
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: e21687b0b8fe1c6812ea43858aa5c1234e05dc6b2c366b280c850fd09d644100cbcf2f3784feec4bc6f57002a465e7eea2901acf1462ffc94ba9ac98f105ede5
   languageName: node
   linkType: hard
 
@@ -6101,7 +12941,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.8.1":
+"promise.allsettled@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "promise.allsettled@npm:1.0.5"
+  dependencies:
+    array.prototype.map: "npm:^1.0.4"
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.1"
+    get-intrinsic: "npm:^1.1.1"
+    iterate-value: "npm:^1.0.2"
+  checksum: 1ed311dbb06e4ec446cd3828d217e88ccf5b90fec8afd257c29a058cc08164ec4c2d503a9f49572d5b4088634cdf6f803bc81f532c3c4457f7a66f7cef5ee31a
+  languageName: node
+  linkType: hard
+
+"promise.prototype.finally@npm:^3.1.0":
+  version: 3.1.3
+  resolution: "promise.prototype.finally@npm:3.1.3"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.1"
+  checksum: dba161ff77cbdc207acb4fbc95e10f8a79950bd4b58b1e9764c993d2148c5bf3a4e3521f0cbb47ae564fba78630ae1cd176620c4648677d36a682a626f29adf9
+  languageName: node
+  linkType: hard
+
+"prompts@npm:^2.4.0":
+  version: 2.4.2
+  resolution: "prompts@npm:2.4.2"
+  dependencies:
+    kleur: "npm:^3.0.3"
+    sisteransi: "npm:^1.0.5"
+  checksum: 3fc5daab8c24a88bceee525b736b255a5b5838676e626d1c401a92925b4c33562b4e424d51770946b898e73d1bf36f0677bd8b3f7b75d1e7cfe838d6dbfc9259
+  languageName: node
+  linkType: hard
+
+"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -6112,6 +12987,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"property-information@npm:^5.0.0, property-information@npm:^5.3.0":
+  version: 5.6.0
+  resolution: "property-information@npm:5.6.0"
+  dependencies:
+    xtend: "npm:^4.0.0"
+  checksum: 8a98c99c2fdfa98f65529c88441decd3a91701ec482bfd14f0afb3ccca6dc88d2fef90f9aba76eb754e9dc9d96e8ae72ca7f73302260111950104645bcd5a508
+  languageName: node
+  linkType: hard
+
+"proxy-addr@npm:~2.0.7":
+  version: 2.0.7
+  resolution: "proxy-addr@npm:2.0.7"
+  dependencies:
+    forwarded: "npm:0.2.0"
+    ipaddr.js: "npm:1.9.1"
+  checksum: c03f00d8f882b97636262d0ae7da0c502325474ea215f21b4f0664ad8f40f49d2071b52c18257d011338be3db21ca65a6e8cbc0d95fb23efc00516ce9ee37c27
+  languageName: node
+  linkType: hard
+
+"prr@npm:~1.0.1":
+  version: 1.0.1
+  resolution: "prr@npm:1.0.1"
+  checksum: a483b1ca81a9f07f6ce2ed354aaa8baffa6ee050b541f49c164975ad1bf154981c80aed3d69441a17c46c804e89fa5f2892909245465270d6cf6631494981fd0
+  languageName: node
+  linkType: hard
+
+"public-encrypt@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "public-encrypt@npm:4.0.3"
+  dependencies:
+    bn.js: "npm:^4.1.0"
+    browserify-rsa: "npm:^4.0.0"
+    create-hash: "npm:^1.1.0"
+    parse-asn1: "npm:^5.0.0"
+    randombytes: "npm:^2.0.1"
+    safe-buffer: "npm:^5.1.2"
+  checksum: d335b26ce380a53e383848ffa5d868388e03c513f26a7c71df7067d91543bb5b10f209b740efadede5bc1019e244b7475b1ee1aebacb206c07522a8db3ab4e23
+  languageName: node
+  linkType: hard
+
+"pump@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pump@npm:2.0.1"
+  dependencies:
+    end-of-stream: "npm:^1.1.0"
+    once: "npm:^1.3.1"
+  checksum: 63959599ac1ac7fae8a2a16116328db643657db6b896eae1f8fc46c464dfe58bce215897a98639e118be99e5b3c6d2b852b89a18f73cc5197916d0808605ae17
+  languageName: node
+  linkType: hard
+
 "pump@npm:^3.0.0":
   version: 3.0.0
   resolution: "pump@npm:3.0.0"
@@ -6119,6 +13044,31 @@ __metadata:
     end-of-stream: "npm:^1.1.0"
     once: "npm:^1.3.1"
   checksum: b2e6702ce154c091b2895cf6f09b35d4db783a3b9658c177387ff6ad00c0e9f6dd9fc5c70f64a3b360bc3624340fca69ff565fad586a206d6818f5e87d836420
+  languageName: node
+  linkType: hard
+
+"pumpify@npm:^1.3.3":
+  version: 1.5.1
+  resolution: "pumpify@npm:1.5.1"
+  dependencies:
+    duplexify: "npm:^3.6.0"
+    inherits: "npm:^2.0.3"
+    pump: "npm:^2.0.0"
+  checksum: 92cd4bb57fbc9a375a5ffd40f7e8b22fb6733e0c49619efe4506bf79bd0c65bbe2e3b2ebeb027d728962b5167e4d3eac06aa95845b231b804108a34a1baf9524
+  languageName: node
+  linkType: hard
+
+"punycode@npm:1.3.2":
+  version: 1.3.2
+  resolution: "punycode@npm:1.3.2"
+  checksum: 55b7339478c7e0debfd563c404beb7c9af30f24e191bd728688523cf1dd901977acdb8bd9c6e1005d3d2fc0f40c7f907006735b139ad1cf595c16e071a1fd65a
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^1.2.4":
+  version: 1.4.1
+  resolution: "punycode@npm:1.4.1"
+  checksum: 6c45a3cd2ba296ffd13488000e947a22b0e7885d2c570f04aef0f4f6f6008f1392b928c3f2bca5fe4c9030bbe94837bdb461050a941df286a597de741397ceb1
   languageName: node
   linkType: hard
 
@@ -6133,6 +13083,45 @@ __metadata:
   version: 1.5.1
   resolution: "q@npm:1.5.1"
   checksum: 276b7e93fc76c4979fba33e571e7ff7dec8c93ee0bed8a8f9b212e4bf5b923bb6b632ce0c8981cbb4b49656cf77c163cba032a7e657cba38401c85957ec92fd4
+  languageName: node
+  linkType: hard
+
+"qs@npm:6.10.3":
+  version: 6.10.3
+  resolution: "qs@npm:6.10.3"
+  dependencies:
+    side-channel: "npm:^1.0.4"
+  checksum: 69daaebb744bec0bd455ac08973c47c3dcbdb389165ceee7522dec41b2b812ecbd2015c09bcc39309efced5d955f849f07dbc4bfdb5b77a360e1ea9a65fc506a
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.10.0":
+  version: 6.11.0
+  resolution: "qs@npm:6.11.0"
+  dependencies:
+    side-channel: "npm:^1.0.4"
+  checksum: 337966e2e957a7d2a69821c528f3d18a8b346ddb0f16cc08d11c6206aed3b6624927781ff437aa3909e54ad32ebdee2c5396ad4094b1c722760774f7082f6124
+  languageName: node
+  linkType: hard
+
+"querystring-es3@npm:^0.2.0":
+  version: 0.2.1
+  resolution: "querystring-es3@npm:0.2.1"
+  checksum: 7f5aaca4c82244148c157b4bf5ecc5e1471c936e0825e06eb8df45fce96f85fc9eb72fd3a76af077260db4b492e2199016d71b9a96e883854439d217019031e6
+  languageName: node
+  linkType: hard
+
+"querystring@npm:0.2.0":
+  version: 0.2.0
+  resolution: "querystring@npm:0.2.0"
+  checksum: 5804c20d7ebf914b26b9fe3c9a4b4b3104d7ee803106ac7bd35b9edffdcd844ca3d4aceaf5e0b39654b6939ceeadebafb3a3975346cf98f7accea19aa97f04fa
+  languageName: node
+  linkType: hard
+
+"querystring@npm:^0.2.0":
+  version: 0.2.1
+  resolution: "querystring@npm:0.2.1"
+  checksum: b0977aff37e25f500731e870ca72627d1732096ff587fd28e4fccfcf358dbea960a3513cbcb58c74f49edd2b42f20eb5aa9660b9b281e5e10ea8de00913d2e4a
   languageName: node
   linkType: hard
 
@@ -6157,7 +13146,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen-typescript@npm:2.2.2":
+"ramda@npm:^0.28.0":
+  version: 0.28.0
+  resolution: "ramda@npm:0.28.0"
+  checksum: 120ec279647aadc8b771b4c0469ad8fb031f38268ebacd95285e92681fa727be54f19d7f386b1cfd7906eb126b8699d84a4a3ecfe1412d41cec0f4e7250ca182
+  languageName: node
+  linkType: hard
+
+"randombytes@npm:^2.0.0, randombytes@npm:^2.0.1, randombytes@npm:^2.0.5, randombytes@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "randombytes@npm:2.1.0"
+  dependencies:
+    safe-buffer: "npm:^5.1.0"
+  checksum: 5d8b58cc7c397c4e23e4ef7d64ecd4a84d4a12781964b5cbd329a92f77f55beef58dda2e8d2f7582aceaf0fd41dac2a9665c630882af1937be8f2fbb5f69d037
+  languageName: node
+  linkType: hard
+
+"randomfill@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "randomfill@npm:1.0.4"
+  dependencies:
+    randombytes: "npm:^2.0.5"
+    safe-buffer: "npm:^5.1.0"
+  checksum: 6d50fc3c3736130c2209407871618ad6d8204db0a54705f3c1a970669760c56e0dac12b875a154fcd1b7b7ff823549d79f40e967ec7eb2e121acad7363011739
+  languageName: node
+  linkType: hard
+
+"range-parser@npm:^1.2.1, range-parser@npm:~1.2.1":
+  version: 1.2.1
+  resolution: "range-parser@npm:1.2.1"
+  checksum: fc96933398c1a37a5c0c02bfc84ae171fa71b6f7b3d4360f84c9faeff5f43f29ebc59b404eab9af00073bb03a9717e05f8c46cd191524b6aefc72f227bad54d5
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:2.5.1":
+  version: 2.5.1
+  resolution: "raw-body@npm:2.5.1"
+  dependencies:
+    bytes: "npm:3.1.2"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.4.24"
+    unpipe: "npm:1.0.0"
+  checksum: b5e41c0e7213e078f045a2b2397eb35665e952ad5176ff7462b740f7c7730b3d47d496ab2b1dd31ed36f8ffed41291cf93b035516403e0babea72c42d039b66b
+  languageName: node
+  linkType: hard
+
+"raw-loader@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "raw-loader@npm:4.0.2"
+  dependencies:
+    loader-utils: "npm:^2.0.0"
+    schema-utils: "npm:^3.0.0"
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: be4770690533b457c059cd8af144c106f73064f59e0165237aef5102f52ccde5818a8c988e53f16b9ec371833847d04cbcfc626652e95b4f6c3ba16df01cc0ce
+  languageName: node
+  linkType: hard
+
+"react-docgen-typescript@npm:2.2.2, react-docgen-typescript@npm:^2.1.1":
   version: 2.2.2
   resolution: "react-docgen-typescript@npm:2.2.2"
   peerDependencies:
@@ -6166,7 +13212,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1":
+"react-docgen@npm:^5.0.0":
+  version: 5.4.3
+  resolution: "react-docgen@npm:5.4.3"
+  dependencies:
+    "@babel/core": "npm:^7.7.5"
+    "@babel/generator": "npm:^7.12.11"
+    "@babel/runtime": "npm:^7.7.6"
+    ast-types: "npm:^0.14.2"
+    commander: "npm:^2.19.0"
+    doctrine: "npm:^3.0.0"
+    estree-to-babel: "npm:^3.1.0"
+    neo-async: "npm:^2.6.1"
+    node-dir: "npm:^0.1.10"
+    strip-indent: "npm:^3.0.0"
+  bin:
+    react-docgen: bin/react-docgen.js
+  checksum: 17fe42dde9f54eb798206b9c6aba633812e3506c820ac6ceea1fe49106fa7311e02f8907535514c49c28a86e8bdb33fd89c1760dfdd0f3c7ee2831f00cf5e2a5
+  languageName: node
+  linkType: hard
+
+"react-element-to-jsx-string@npm:^14.3.4":
+  version: 14.3.4
+  resolution: "react-element-to-jsx-string@npm:14.3.4"
+  dependencies:
+    "@base2/pretty-print-object": "npm:1.0.1"
+    is-plain-object: "npm:5.0.0"
+    react-is: "npm:17.0.2"
+  peerDependencies:
+    react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
+    react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
+  checksum: 3496149348a186b84f11d5d519d07d82597f8d60525a984e96428d0744c3dc155b67f39787791c5987ed6b1feed5b42a1ef8e1c6dcf64f610e5cfa1a41cfc861
+  languageName: node
+  linkType: hard
+
+"react-is@npm:17.0.2":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 24af7af3abd0bf94d4eb018a70db25fd4e23648eec7bb8b203bf59e24a715ac4eec8279939e15a4d90cbad19ed6be243a0f2c9aa0b1faec0a1c102d9c89ca3f9
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 0c9adc5d984db733fb1dd298f3e94cdec66bc328d27fb11df65971d2cc9a299008bc64baab8fe8e79943df85b445a1008b2cc9e270825d0fd056e5a0d2df8de6
@@ -6180,12 +13267,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-refresh@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "react-refresh@npm:0.11.0"
+  checksum: ff741e2a0646da20314dba28ca740e25342df9a909cf1087ab659940bb65fbad86ea9d5b11f923643a442e3c9d2a4eba1152c584724da85b71c80b7c18d2bf2c
+  languageName: node
+  linkType: hard
+
+"react-syntax-highlighter@npm:^15.4.5":
+  version: 15.5.0
+  resolution: "react-syntax-highlighter@npm:15.5.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    highlight.js: "npm:^10.4.1"
+    lowlight: "npm:^1.17.0"
+    prismjs: "npm:^1.27.0"
+    refractor: "npm:^3.6.0"
+  peerDependencies:
+    react: ">= 0.14.0"
+  checksum: b10f31e6ac325186c2b605efa5011c6f2b359d42c86f97f5912f01b6a9f3e60c161cbe45e0a647cb909043bfaf3d66edcd34923baef5b1ef85303500ea06a034
+  languageName: node
+  linkType: hard
+
 "react@npm:18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
   dependencies:
     loose-envify: "npm:^1.1.0"
   checksum: 8434e5782c52b3bf18a80b666348977924ee3827895fa03ec3ffb9faca90c460049f14130428dd1546bab6cf3b2c277f2c243d3c2a856501331d2e69c24b2bb9
+  languageName: node
+  linkType: hard
+
+"read-pkg-up@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "read-pkg-up@npm:1.0.1"
+  dependencies:
+    find-up: "npm:^1.0.0"
+    read-pkg: "npm:^1.0.0"
+  checksum: 67db75f9fef4ccaa81f04bce1fa58a774e42f6c42f26570d9db69232ba358da4219db5db3458f566b049635854e5ff0ba2146a8ea34585374ab84c6ea2c3fc59
   languageName: node
   linkType: hard
 
@@ -6208,6 +13327,17 @@ __metadata:
     read-pkg: "npm:^6.0.0"
     type-fest: "npm:^1.0.1"
   checksum: c5180c8d3ebaa448e0b085c5bf68596ea607f7bb1d98aa5d2ca35b9c27b3b917a69b482fbcd9a307ea793ff21a22f49d69d1e0f5c506f6d25b7034c203ca7f44
+  languageName: node
+  linkType: hard
+
+"read-pkg@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "read-pkg@npm:1.1.0"
+  dependencies:
+    load-json-file: "npm:^1.0.0"
+    normalize-package-data: "npm:^2.3.2"
+    path-type: "npm:^1.0.0"
+  checksum: c12be26451488b0b3aab5dc9341f37236edd0942f6932840e4481e1abcf53ee76c3f9d999b83cb3f4641e1f3bf8a8a2458d6b7292511b32e000b9e5cb932d452
   languageName: node
   linkType: hard
 
@@ -6235,6 +13365,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:1 || 2, readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.1.5, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.6, readable-stream@npm:~2.3.6":
+  version: 2.3.7
+  resolution: "readable-stream@npm:2.3.7"
+  dependencies:
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.3"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~2.0.0"
+    safe-buffer: "npm:~5.1.1"
+    string_decoder: "npm:~1.1.1"
+    util-deprecate: "npm:~1.0.1"
+  checksum: 23c757366d6e0dd9115660c7313d10fc6a57fa50f5a62d1fde329cee13d4bc0de7f3db6d2f25722b1bd98171abe3d4bea626545556b4684864e20ecc70a2a57d
+  languageName: node
+  linkType: hard
+
 "readable-stream@npm:3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.6.0":
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
@@ -6243,6 +13388,26 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: bda7b24d3910bf0ec4a1df3c540e1b97b1ed3ca49ea0ddc0d2c6bf29d3997251a7244608de1d842555641d1c115d9b3566167fef9225ee6ef147c9e6a539395b
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "readdirp@npm:2.2.1"
+  dependencies:
+    graceful-fs: "npm:^4.1.11"
+    micromatch: "npm:^3.1.10"
+    readable-stream: "npm:^2.0.2"
+  checksum: a6124027b14fddc89aaf013e215336ea725dc65a107ad01d9ef6aabe3546b0cd4f65c337c6df0e793daab96f4a237049fc403b30bc21be87152ff1e849b490fa
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
+  dependencies:
+    picomatch: "npm:^2.2.1"
+  checksum: 9dea77bef6b47b7c7553da4b5f30606449b49cf2aa043de23e22bee909c2d26c97630b8f8fa43775e318731c5a208d2063a10d3c788a3b0e1a9e32c5ab5fe790
   languageName: node
   linkType: hard
 
@@ -6255,6 +13420,16 @@ __metadata:
     slash: "npm:^3.0.0"
     tslib: "npm:^1.9.3"
   checksum: adba5499275534dc66052b7b40446222ab4a83eb6eab3c15470ced19dc09f32f4f6a53feecc4f7ef60a52db7d06955e5df5c3b5705fbd47bbbf3ff8733964a12
+  languageName: node
+  linkType: hard
+
+"redent@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "redent@npm:1.0.0"
+  dependencies:
+    indent-string: "npm:^2.1.0"
+    strip-indent: "npm:^1.0.1"
+  checksum: f734ca2702e8e3611299cb3096d03f402c694660ed09de435090ff133afd56db2428bc09930028f6bc59749c5a8a0206acc22a080f48ad07e1afae03907d019b
   languageName: node
   linkType: hard
 
@@ -6275,6 +13450,59 @@ __metadata:
     indent-string: "npm:^5.0.0"
     strip-indent: "npm:^4.0.0"
   checksum: a04affcfec9913c2cfda142f7a3f15ff28a46d036ab0630a60d8ea107c2cdf72453b6fbc140cc8dbd0bcf71a6e2d4c918281aaffd4ef3610af897ad30b8988ca
+  languageName: node
+  linkType: hard
+
+"refractor@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "refractor@npm:3.6.0"
+  dependencies:
+    hastscript: "npm:^6.0.0"
+    parse-entities: "npm:^2.0.0"
+    prismjs: "npm:~1.27.0"
+  checksum: 388dec9c5b99b161eb5eca896ee09e8350c4fdef49c9fbcb24ad31fd5951046280837f47b150d5f0c1af28a215d1fc2f316de57addae0af999d8cee95e82bb72
+  languageName: node
+  linkType: hard
+
+"regenerate-unicode-properties@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "regenerate-unicode-properties@npm:10.0.1"
+  dependencies:
+    regenerate: "npm:^1.4.2"
+  checksum: 551c4eb58bcde309e942b2e721271d07c728381456cb86a98c522e73e47a95b91d07bd7d932d38b7444f3e5d348242b005f87217d9ac0c496ebb66d87cefb23e
+  languageName: node
+  linkType: hard
+
+"regenerate@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "regenerate@npm:1.4.2"
+  checksum: f2d97117f52ef5bef7757693c3157395c8c542ef4b856addac6e78c76ed7053f2154435912a18a6d1c3ff09702ad525babeffe30a179ef809cacff200cd4d193
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.4, regenerator-runtime@npm:^0.13.7":
+  version: 0.13.9
+  resolution: "regenerator-runtime@npm:0.13.9"
+  checksum: db060af0b2ca8bb7f12aea9dcf7416ff80259b39c2ddd38e0bd705b0a7acd9f07be133e543bbf54af1e86253b6fd553e3050fd6b30c3282731dd27560427f065
+  languageName: node
+  linkType: hard
+
+"regenerator-transform@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "regenerator-transform@npm:0.15.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.8.4"
+  checksum: 275bd346e27f3f3e3940ef27ff10fce579941d13be545465649860b3e9d01304ef39d3045a0a7fd70a0d48bac28ccc4ef054cd126b2c5cd473093c31fc8f995f
+  languageName: node
+  linkType: hard
+
+"regex-not@npm:^1.0.0, regex-not@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "regex-not@npm:1.0.2"
+  dependencies:
+    extend-shallow: "npm:^3.0.2"
+    safe-regex: "npm:^1.1.0"
+  checksum: 98ef0dc9de7cfb315c7a6362e062e16926dc73ab33bf2fec90116a19755a2b1dc8866238a1db1f718f148889584f6e72a6f250059901fb90f34e2a72ace21e94
   languageName: node
   linkType: hard
 
@@ -6305,10 +13533,141 @@ __metadata:
   languageName: node
   linkType: hard
 
-"repeat-string@npm:^1.6.1":
+"regexpu-core@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "regexpu-core@npm:5.1.0"
+  dependencies:
+    regenerate: "npm:^1.4.2"
+    regenerate-unicode-properties: "npm:^10.0.1"
+    regjsgen: "npm:^0.6.0"
+    regjsparser: "npm:^0.8.2"
+    unicode-match-property-ecmascript: "npm:^2.0.0"
+    unicode-match-property-value-ecmascript: "npm:^2.0.0"
+  checksum: eb3c2d2a9a85a3559e001c52c8f42cfea8cbbcebdc841e0f71a540fa92a3dcf0e1e24312269d01df1478f20a838b9051c66038281fe0426603c6fd1f408b621a
+  languageName: node
+  linkType: hard
+
+"regjsgen@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "regjsgen@npm:0.6.0"
+  checksum: 194b4e28d881448023ffc08c06e2602e88115d44cdd38021bad5c5c77c18833598889c683859b87ca8d3fc20df37a8a124bfac0dbc98ca05fb44b9994a793f14
+  languageName: node
+  linkType: hard
+
+"regjsparser@npm:^0.8.2":
+  version: 0.8.4
+  resolution: "regjsparser@npm:0.8.4"
+  dependencies:
+    jsesc: "npm:~0.5.0"
+  bin:
+    regjsparser: bin/parser
+  checksum: 8d370d309ad77094d5b2fa57d5ccf9e37929f5d1ef7e5374eb233d8e470b5e41bbe150fad9629959393f57855ca0a54ea5472fc91e933f695adb17198382424f
+  languageName: node
+  linkType: hard
+
+"relateurl@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "relateurl@npm:0.2.7"
+  checksum: 18af464c6bd59aae9f7906c600ef59ed604b41144a82a9f15aacafa94289edbc13df35b2000aaf6179c881a91b93ef669f67e21a45f6da594560dc4a9d8a3e8a
+  languageName: node
+  linkType: hard
+
+"remark-footnotes@npm:2.0.0":
+  version: 2.0.0
+  resolution: "remark-footnotes@npm:2.0.0"
+  checksum: 98ee46c6a737876a5bd44e5131d91cf3eaab6c5d7ac6b19aec6635a59c9ba2e4253ba69d35eecaa10990de11c2a8d626f19e1c1b8c9a1bfd36bf97832226bf37
+  languageName: node
+  linkType: hard
+
+"remark-mdx@npm:1.6.22":
+  version: 1.6.22
+  resolution: "remark-mdx@npm:1.6.22"
+  dependencies:
+    "@babel/core": "npm:7.12.9"
+    "@babel/helper-plugin-utils": "npm:7.10.4"
+    "@babel/plugin-proposal-object-rest-spread": "npm:7.12.1"
+    "@babel/plugin-syntax-jsx": "npm:7.12.1"
+    "@mdx-js/util": "npm:1.6.22"
+    is-alphabetical: "npm:1.0.4"
+    remark-parse: "npm:8.0.3"
+    unified: "npm:9.2.0"
+  checksum: 0b3fe833dfbe2be6dd3977b8d40144514e3938cf4fcee99a09e3ae4a458116743b629fb64439cce3c4d19e34d58f234661db8fb821e2329668c2c2c58102a27d
+  languageName: node
+  linkType: hard
+
+"remark-parse@npm:8.0.3":
+  version: 8.0.3
+  resolution: "remark-parse@npm:8.0.3"
+  dependencies:
+    ccount: "npm:^1.0.0"
+    collapse-white-space: "npm:^1.0.2"
+    is-alphabetical: "npm:^1.0.0"
+    is-decimal: "npm:^1.0.0"
+    is-whitespace-character: "npm:^1.0.0"
+    is-word-character: "npm:^1.0.0"
+    markdown-escapes: "npm:^1.0.0"
+    parse-entities: "npm:^2.0.0"
+    repeat-string: "npm:^1.5.4"
+    state-toggle: "npm:^1.0.0"
+    trim: "npm:0.0.1"
+    trim-trailing-lines: "npm:^1.0.0"
+    unherit: "npm:^1.0.4"
+    unist-util-remove-position: "npm:^2.0.0"
+    vfile-location: "npm:^3.0.0"
+    xtend: "npm:^4.0.1"
+  checksum: 066b10c31dd8eb88c79266f06d5235a2d207147d6765f3d291fd1b00c347fe178e9bbfaa820c177acda390fabe2249ed6cdd8002857c154ab4d70aed129ead73
+  languageName: node
+  linkType: hard
+
+"remark-squeeze-paragraphs@npm:4.0.0":
+  version: 4.0.0
+  resolution: "remark-squeeze-paragraphs@npm:4.0.0"
+  dependencies:
+    mdast-squeeze-paragraphs: "npm:^4.0.0"
+  checksum: 5fedfbe978905f344f084527054c98a5ac97b67ba8239c5b78b6e88d647a4710f772504b48bdf298bc8f3fae77f5cd938a6679d8156db9a3ba9e6362288509db
+  languageName: node
+  linkType: hard
+
+"remove-trailing-separator@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "remove-trailing-separator@npm:1.1.0"
+  checksum: 3ccd7a52d93044ca11dcc29292bfa3167f42083e45263c096d38adc3174c15ad537215c15f22d85359fbad6067a58fce528d2cf4464e398a1558835de5b4cae6
+  languageName: node
+  linkType: hard
+
+"renderkid@npm:^2.0.4":
+  version: 2.0.7
+  resolution: "renderkid@npm:2.0.7"
+  dependencies:
+    css-select: "npm:^4.1.3"
+    dom-converter: "npm:^0.2.0"
+    htmlparser2: "npm:^6.1.0"
+    lodash: "npm:^4.17.21"
+    strip-ansi: "npm:^3.0.1"
+  checksum: e86dcbb0e29ca5afe27a400047050cfbc60b9ae97fa85564f4d046dea0dbc345dbbc4d45387a6ac33a1d402f6dab5257c41495c3336c1d547441c6036cb434af
+  languageName: node
+  linkType: hard
+
+"repeat-element@npm:^1.1.2":
+  version: 1.1.4
+  resolution: "repeat-element@npm:1.1.4"
+  checksum: 2ff55b8a4b8112a85738a6b7daf1139380aec40504bec51f145ce8cddb5704db2cca9dab76789948c7f34ce52950edcf4a02cf2fb1bd9a71b8a2feb5dc340dfe
+  languageName: node
+  linkType: hard
+
+"repeat-string@npm:^1.5.4, repeat-string@npm:^1.6.1":
   version: 1.6.1
   resolution: "repeat-string@npm:1.6.1"
   checksum: aa893b7e42c56727dce0f9bf902c5156b9b914c3a31b4a3831e673d43502ce7613311ba38b2c1852c7ea4f9f88e10aa985e162e7ae2e424e0a0ebd761b21f678
+  languageName: node
+  linkType: hard
+
+"repeating@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "repeating@npm:2.0.1"
+  dependencies:
+    is-finite: "npm:^1.0.0"
+  checksum: eb19209a3c9bd0762e71832f4f54df5e2f7a4f78d8b622fc46bcdc15772b7f880bf1762d1d3566adfaa8b37f243b5e0f83eaa279b2381af762b71c97b6cc186c
   languageName: node
   linkType: hard
 
@@ -6364,7 +13723,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.22.0, resolve@npm:^1.22.1":
+"resolve-url@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "resolve-url@npm:0.2.1"
+  checksum: 04512ab3c357b92f86ea4a3852af8e3bbcdd845bfe7385ab229af5ae3d6ff61df664bc99915581660e0630e03a53c361637d03cc711be601072c5f1aa7c7d6ba
+  languageName: node
+  linkType: hard
+
+"resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.14.2, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.22.1, resolve@npm:^1.3.2":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
   dependencies:
@@ -6390,7 +13756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.3.2#optional!builtin<compat/resolve>":
   version: 1.22.1
   resolution: "resolve@patch:resolve@npm%3A1.22.1#optional!builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
@@ -6426,6 +13792,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ret@npm:~0.1.10":
+  version: 0.1.15
+  resolution: "ret@npm:0.1.15"
+  checksum: d65bd0cc83122e33a284e87ff9b51f553e5da3d05b0643740a0c07189f6025972a70856e794bdae3d8cdfb36bc8c05a3aad3935bdadbd20bdaa1789b70a21e8c
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -6447,6 +13820,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rimraf@npm:^2.5.4, rimraf@npm:^2.6.3":
+  version: 2.7.1
+  resolution: "rimraf@npm:2.7.1"
+  dependencies:
+    glob: "npm:^7.1.3"
+  bin:
+    rimraf: ./bin.js
+  checksum: 35e2f6ca89242c02380f70895af2caf2b8a31e5a9b05b380ebf0aa5f48005ec9d242eb4fb32d8578a34c42dc012d16866dfc0e0d0b8601ec8c72ff7065755f19
+  languageName: node
+  linkType: hard
+
 "rimraf@npm:^3.0.2":
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
@@ -6455,6 +13839,16 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: b786c9ad52df9fbcd9c7120e105f3150b83b39dd87d9235a93b0c7e806575e1e68936504ff64563dbe67b3f8bbbc00bdfff586157d402ee8990e7143456511c0
+  languageName: node
+  linkType: hard
+
+"ripemd160@npm:^2.0.0, ripemd160@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "ripemd160@npm:2.0.2"
+  dependencies:
+    hash-base: "npm:^3.0.0"
+    inherits: "npm:^2.0.1"
+  checksum: 4541eb0cc604d08c00681d03e1648911d52a2c0f944df01673420c1bf7f94722e0b604e40a7c5bf1a037efbcf4de906235ed3e6ae0f7b967eab66bec8eff8436
   languageName: node
   linkType: hard
 
@@ -6490,18 +13884,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-friendly-type-imports@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "rollup-plugin-friendly-type-imports@npm:1.0.3"
-  dependencies:
-    typescript: "npm:^4.5.5"
-  checksum: 37e6c7e7708e1beee177fb8f9ddd8cc6a9d95ace15c65071cb7cd5ca6b88a4a8582b4fc251f5aef3e1f39773e3f9928886ed67b9cddc497a7e96312748d3f155
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^2.59.0, rollup@npm:^2.75.6, rollup@npm:^2.77.0":
-  version: 2.77.0
-  resolution: "rollup@npm:2.77.0"
+"rollup@npm:^2.75.6, rollup@npm:^2.77.0":
+  version: 2.77.2
+  resolution: "rollup@npm:2.77.2"
   dependencies:
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
@@ -6509,7 +13894,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 26d3073a8f58a1da6fcb02142faccef7e8c1711a02cc7e6d0940b9000c4963b5ac35eeb252ebd4033d048305e90679357dd622d6a3c55de378386c825bb053a5
+  checksum: 98bbbb1f2a6e140238ce3a21748182a4220c115bc43ae15051bfe9ce18d716f1f274bc5f476586b624c7339d3d0ee27d8436bce5d4ca1e5e854a207a41ac2e39
   languageName: node
   linkType: hard
 
@@ -6522,6 +13907,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"run-queue@npm:^1.0.0, run-queue@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "run-queue@npm:1.0.3"
+  dependencies:
+    aproba: "npm:^1.1.1"
+  checksum: fa9a8e7afde280d2fa189ba4f054d3d26bca0056431aa193f8ba82f9b638c984af6c51fa05af829925b0f4cb923448bed7cc9cc68c9066f69e3bfbad3fae837f
+  languageName: node
+  linkType: hard
+
 "rxjs@npm:^7.5.5":
   version: 7.5.6
   resolution: "rxjs@npm:7.5.6"
@@ -6531,17 +13925,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.1.1":
+"safe-buffer@npm:5.1.1":
+  version: 5.1.1
+  resolution: "safe-buffer@npm:5.1.1"
+  checksum: 9949e41ce8a45ed808517d2db35ae17ed5554c17e5ad1ed866f508c476ed61d666d9edf7fc88ab850a104becb90162bf8d4f0cb5634e53105c78de139f93a6f3
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: 86939c6de6b62c1d39b7da860a56d5e50ede9b0ab35a91b0620bff8a96f1f798084ff910059f605087c2c500dc23dfdf77ff5bc3bcc8d4d38e3d634de2e3e426
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: da8a21b3336a21c152eb3ba8ab41acde5772644f026d4b6e5f9fd8afa4f0cf407c113b19a362580fab9aea8beea295465432fc7684f9ff38aac559bb1b5528cd
+  languageName: node
+  linkType: hard
+
+"safe-regex@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "safe-regex@npm:1.1.0"
+  dependencies:
+    ret: "npm:~0.1.10"
+  checksum: 6bd6b882088cc0cd2d1dc3dabe1c85edb6f324975b8641b72419afaab3edfa641e8a27f6f5fef8ab2c5aa17527dc07d53da53d3dccbc6fe1fbe8540814175289
   languageName: node
   linkType: hard
 
@@ -6554,10 +13964,54 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3.0.0":
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.1.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: d4199666e9e792968c0b88c2c35dd400f56d3eecb9affbcf5207922822eadf30cc06995bae3c5d0a653851bbd40fc0af578bf046bbf734199ce22433ba4da659
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:2.7.0":
+  version: 2.7.0
+  resolution: "schema-utils@npm:2.7.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.4"
+    ajv: "npm:^6.12.2"
+    ajv-keywords: "npm:^3.4.1"
+  checksum: 263efbe4d2e5a2a6cb0bc4e15cecb1d4bc8320713fa83b5e34e7cd3eda257568cf9c4ad04042a5215ff8460821a96b070a1e8677095434368b9fd1b5b94956d6
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "schema-utils@npm:1.0.0"
+  dependencies:
+    ajv: "npm:^6.1.0"
+    ajv-errors: "npm:^1.0.0"
+    ajv-keywords: "npm:^3.1.0"
+  checksum: 129214e1e75a90d84f2800ec4daa9a97a48d8a5ac94389774d961983b4b794fdee62af68c627c088f098587e73162efa8896e5a21c5231ee94e628642c9618f0
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^2.6.5, schema-utils@npm:^2.7.0":
+  version: 2.7.1
+  resolution: "schema-utils@npm:2.7.1"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.5"
+    ajv: "npm:^6.12.4"
+    ajv-keywords: "npm:^3.5.2"
+  checksum: 80a77b8fe8793a81a37fb4915a1c7c93b9f43029a3f6d8e1971574ae1dd8808114ead54bd1f6c50c66988050e85126238cd61c0151b4894187e92bea8c661130
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "schema-utils@npm:3.1.1"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.8"
+    ajv: "npm:^6.12.5"
+    ajv-keywords: "npm:^3.5.2"
+  checksum: f33eda6fc4def7012a3169cd97cd41b2fc0cc26219c456bbc3f49265bc00eec7d044484cfba330c20692091931901a2381a7f21c7e1f48c3106ff3dcef353bf9
   languageName: node
   linkType: hard
 
@@ -6568,7 +14022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.4.1, semver@npm:^5.6.0":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
   bin:
@@ -6577,7 +14031,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.7, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
+"semver@npm:7.0.0":
+  version: 7.0.0
+  resolution: "semver@npm:7.0.0"
+  bin:
+    semver: bin/semver.js
+  checksum: c0b7fdd720c6ee955cd71172ef8d63f41976d70049f02aa7569edff0ab89846ee035e39c82f3733fd2af3285f6ca6e14c3778e8de84cd8ea6ec1a33c68bf072a
+  languageName: node
+  linkType: hard
+
+"semver@npm:7.3.7, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
   version: 7.3.7
   resolution: "semver@npm:7.3.7"
   dependencies:
@@ -6588,7 +14051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.3.0":
+"semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.3.0":
   version: 6.3.0
   resolution: "semver@npm:6.3.0"
   bin:
@@ -6597,10 +14060,137 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:0.18.0":
+  version: 0.18.0
+  resolution: "send@npm:0.18.0"
+  dependencies:
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    destroy: "npm:1.2.0"
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
+    mime: "npm:1.6.0"
+    ms: "npm:2.1.3"
+    on-finished: "npm:2.4.1"
+    range-parser: "npm:~1.2.1"
+    statuses: "npm:2.0.1"
+  checksum: 670f134b35017d77ae82b02f04f5529651c4970887a5ffc581f003ed3858f8bda991eb1213e3b94f3c98acdcfc6a16cf83b58d330892662efe41d1d0d7993838
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "serialize-javascript@npm:4.0.0"
+  dependencies:
+    randombytes: "npm:^2.1.0"
+  checksum: f32ca5430abbbc6f72eff8abf62715d6f22abf517d3b398186d4d520e640695c70207319d7c1c758c844df11f56c2deedcf511483b22a0fc845f9f8c93a26b0b
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "serialize-javascript@npm:5.0.1"
+  dependencies:
+    randombytes: "npm:^2.1.0"
+  checksum: 67c9ec3fea14b2999556662799e420b69208138a63e56752c403c12a88a0e5ca384487655a27b2132c4f2a3f71372a9ca21a655b8973cb75552fb9ff7531b8f3
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "serialize-javascript@npm:6.0.0"
+  dependencies:
+    randombytes: "npm:^2.1.0"
+  checksum: c54759aaf8581cc1509e838a9a1eb340b0addaf8103f1d7795af0cd2319475e43cc31793fbe2db72aa8059a93218dc22b79ae8277b0e69de474a4f79800cf54f
+  languageName: node
+  linkType: hard
+
+"serve-favicon@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "serve-favicon@npm:2.5.0"
+  dependencies:
+    etag: "npm:~1.8.1"
+    fresh: "npm:0.5.2"
+    ms: "npm:2.1.1"
+    parseurl: "npm:~1.3.2"
+    safe-buffer: "npm:5.1.1"
+  checksum: 170c514861720a24f7ba3226551ef2e17c2ea7fbb5eff041d95455e9003facf8453f5cff518c14214226c0b025ea2d7fedff9010c84f61e6852c9d59fb303191
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:1.15.0":
+  version: 1.15.0
+  resolution: "serve-static@npm:1.15.0"
+  dependencies:
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    parseurl: "npm:~1.3.3"
+    send: "npm:0.18.0"
+  checksum: 38b4b126ef7497103b0466c1b876e2ad9732d3a32a905ef6b54681525802a2defba6e8e48c136f68c666e48f8c2dc869d24060b0a83f1dbdf724632cccf072fe
+  languageName: node
+  linkType: hard
+
 "set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 9e8f5aeb7cd850a60b5dbf47d42051137c14f58f375d9a70ca227b797d6ffed3dabf659587d2f183231085f1da2dc3067e2af9f5fcd66fb65c98da5fb54a22fb
+  languageName: node
+  linkType: hard
+
+"set-value@npm:^2.0.0, set-value@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "set-value@npm:2.0.1"
+  dependencies:
+    extend-shallow: "npm:^2.0.1"
+    is-extendable: "npm:^0.1.1"
+    is-plain-object: "npm:^2.0.3"
+    split-string: "npm:^3.0.1"
+  checksum: 272c54bf66c4c3457fa5d950a1f7067f17264726cc0a3a393e98d3529f14475598949ed6801ed26ccaa38787be3e5e41e86a0dc492275916e6a00957214e7d68
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.4":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: 915f34e42dbc1602fee8407784b4775ff88087ba84a05a069c15711dc7b23e9d6fd514ede7133c8496525afe41c343f1827a6f8f50e925c962b853594a60ac26
+  languageName: node
+  linkType: hard
+
+"setprototypeof@npm:1.2.0":
+  version: 1.2.0
+  resolution: "setprototypeof@npm:1.2.0"
+  checksum: ba389f4722581d9070df0a323a29501254594a97fee0e9308e73372f9856dbdb37fff71a0fef1e31c48901384544260d12925b791477e0101d7a68a6e28c23cf
+  languageName: node
+  linkType: hard
+
+"sha.js@npm:^2.4.0, sha.js@npm:^2.4.8":
+  version: 2.4.11
+  resolution: "sha.js@npm:2.4.11"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+  bin:
+    sha.js: ./bin.js
+  checksum: c95a5988bc29c4bf645ed67f1eaa8a841cb6332914bd87f63f8f7b83460671878226be0af9eccf28b61dd1746c594c8ce46af1907c77568382b5fe3b84f2dc13
+  languageName: node
+  linkType: hard
+
+"shallow-clone@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "shallow-clone@npm:3.0.1"
+  dependencies:
+    kind-of: "npm:^6.0.2"
+  checksum: 4b5c12c1cf13c645cdfbc71c1e367bb57106d81313fb5c8de0122029a23fca8ff1ab210007b78d621a430af26d2efea27a68fd927e2976ff7ad905619438b37e
+  languageName: node
+  linkType: hard
+
+"shallowequal@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "shallowequal@npm:1.1.0"
+  checksum: 9ffaad8074fc1ff1b0ac6b58b8d3f000daa86d8ad1a3122d0dbf218ec777e3c5d2c753223684b46c1b886a66bc9fcd5cfea811e8bb39964220e05845182ae17a
   languageName: node
   linkType: hard
 
@@ -6638,21 +14228,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 5cf7525c55a72d8d104d914acf2e470f74b2c156197277ad7b331bc5de3d8790170fed3c82ff98c7c31adaa8ff941bfd5ba44f55171cbe8ed0e939fa82a8322a
-  languageName: node
-  linkType: hard
-
-"simple-git@npm:3.10.0":
-  version: 3.10.0
-  resolution: "simple-git@npm:3.10.0"
-  dependencies:
-    "@kwsites/file-exists": "npm:^1.1.1"
-    "@kwsites/promise-deferred": "npm:^1.1.1"
-    debug: "npm:^4.3.4"
-  checksum: bedc0b231ddf935c434b91cf77aa49325571430761c7274c546648f29ba9f22a2622ea7243af6d7ef7ac03ea2b66e6922e90cffa092a6e6d4efa55e148985698
   languageName: node
   linkType: hard
 
@@ -6667,10 +14246,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sisteransi@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "sisteransi@npm:1.0.5"
+  checksum: 35461425fe53c7cf8e2abdc5cef4568247b41bade0b7fcf316923aae6e3a59004d35e6a7e26f3be345b8fc7091cf2d589974d0df5469a05d049d2f95974dd17d
+  languageName: node
+  linkType: hard
+
 "slash@npm:^1.0.0":
   version: 1.0.0
   resolution: "slash@npm:1.0.0"
   checksum: e0e05887dc446179ac39db0676990170778ffde456354cd5798fba7765cfffcd27ac046f99063ef2382338dbee7686043eca21e479b682c3f909f93d2b964a7e
+  languageName: node
+  linkType: hard
+
+"slash@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "slash@npm:2.0.0"
+  checksum: e53840c4398131459758dcad3ed7f44346198f432f7c7ed96d75b750d3e1814a02368e10252bb3ee312bc87379359887ce0783a91a2a391121c52cef93411ac8
   languageName: node
   linkType: hard
 
@@ -6720,6 +14313,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"snapdragon-node@npm:^2.0.1":
+  version: 2.1.1
+  resolution: "snapdragon-node@npm:2.1.1"
+  dependencies:
+    define-property: "npm:^1.0.0"
+    isobject: "npm:^3.0.0"
+    snapdragon-util: "npm:^3.0.1"
+  checksum: 3f2894034cf8f282cad54dab688807eca9eb3d38cee0a503fa0fb7c33896a4f38b84519ec65bdae83651512529f07fd589c535c543fcfbcd87e2d40173a1dbb1
+  languageName: node
+  linkType: hard
+
+"snapdragon-util@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "snapdragon-util@npm:3.0.1"
+  dependencies:
+    kind-of: "npm:^3.2.0"
+  checksum: 31a4a34b89c37e0bb1c328d83718de19a4d19e999a4fad426beda60bb4730cb5fa43448fa359eb9e3ef0c2933682bc76f1e63434059e67591d0cb02c9c43996b
+  languageName: node
+  linkType: hard
+
+"snapdragon@npm:^0.8.1":
+  version: 0.8.2
+  resolution: "snapdragon@npm:0.8.2"
+  dependencies:
+    base: "npm:^0.11.1"
+    debug: "npm:^2.2.0"
+    define-property: "npm:^0.2.5"
+    extend-shallow: "npm:^2.0.1"
+    map-cache: "npm:^0.2.2"
+    source-map: "npm:^0.5.6"
+    source-map-resolve: "npm:^0.5.0"
+    use: "npm:^3.1.0"
+  checksum: b110aefa2367ecfd85a874a10a1104e2e058613b51793b678e43c3e35a0e2c183f6b641c6e79f35a9f7150526ebce65dc5dc0102deaedd540c6cb334ed364250
+  languageName: node
+  linkType: hard
+
 "socks-proxy-agent@npm:^7.0.0":
   version: 7.0.0
   resolution: "socks-proxy-agent@npm:7.0.0"
@@ -6741,6 +14370,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-list-map@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "source-list-map@npm:2.0.1"
+  checksum: 0c847a4c46ede845d6ff12636322973e1f56035e722d035122d37007cf64c5ad67c462973b2ed756db161aaaf30b6be8b4df9a6d6163c92c52c4a7946f99c7ae
+  languageName: node
+  linkType: hard
+
 "source-map-js@npm:^1.0.2":
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
@@ -6748,10 +14384,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-resolve@npm:^0.5.0":
+  version: 0.5.3
+  resolution: "source-map-resolve@npm:0.5.3"
+  dependencies:
+    atob: "npm:^2.1.2"
+    decode-uri-component: "npm:^0.2.0"
+    resolve-url: "npm:^0.2.1"
+    source-map-url: "npm:^0.4.0"
+    urix: "npm:^0.1.0"
+  checksum: 6d112dffb945452a1825e62f57e23a90e0e1132ec0705da2483bec5f8543bb5788d3616dd77ac037f455b43850d23af94ee595b948d9aaf2145d8c92c07d89b9
+  languageName: node
+  linkType: hard
+
+"source-map-support@npm:^0.5.16, source-map-support@npm:~0.5.12, source-map-support@npm:~0.5.20":
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
+  dependencies:
+    buffer-from: "npm:^1.0.0"
+    source-map: "npm:^0.6.0"
+  checksum: ab0f9bfbcfc32018966a7199de5aeafee03a38408852400962d302392aab16d670dc84e6eda937570c5ff09972ae23347804cdffc5fe3c5e382a5b04cee3d580
+  languageName: node
+  linkType: hard
+
+"source-map-url@npm:^0.4.0":
+  version: 0.4.1
+  resolution: "source-map-url@npm:0.4.1"
+  checksum: dafa9f0ae5a0c6f3bcdb6b3d96770e45bd75917429475200a8d36894b2366566350b00a9839892e12c2da8bff49629d266b4476efdd7ceec033f968347461770
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.5.0, source-map@npm:^0.5.6":
+  version: 0.5.7
+  resolution: "source-map@npm:0.5.7"
+  checksum: fd1c3c795c360e43fed3f7e80ff227c2156dbe3c69d20a9bf9c4b299a1cbe412cb6f9561fc6f636496f1bf44a28a06edcc0fb4a16de17db903481a063683f45a
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.0, source-map@npm:~0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: cba9f44c3a4a0485f44a7760ebe427eecdd3b58011ae0459c05506b54f898835b2302073d6afa563a19b60ee9e54c82e33bc4a032e28bebacdfc635f1d0bf7e0
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.7.3":
+  version: 0.7.4
+  resolution: "source-map@npm:0.7.4"
+  checksum: 97353dd6ffe747221f810400254a2c0110d745758aa094d3efe697d15c7697bb9bf49fea7028e88e97f973af53ac98cf69522ced606a4b46428fdd3e0d759280
+  languageName: node
+  linkType: hard
+
 "sourcemap-codec@npm:^1.4.8":
   version: 1.4.8
   resolution: "sourcemap-codec@npm:1.4.8"
   checksum: 16bd825c262a260854606ce89d836312a36a9b7d70fba54f17c2d9c395ad99a61b4f6b333f3f830ce09a37c234668ff6a7ece172b9964a2d78f9d433bf0e1e93
+  languageName: node
+  linkType: hard
+
+"space-separated-tokens@npm:^1.0.0":
+  version: 1.1.5
+  resolution: "space-separated-tokens@npm:1.1.5"
+  checksum: 375ab0827971a2ffe2c14bcdba23bd6562e3810973fc4d66e043ce711e90d075669a13a4d51020dc7d2141227cfd6c19d940a832e96815273eaa5498f9473a03
   languageName: node
   linkType: hard
 
@@ -6789,12 +14483,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split-string@npm:^3.0.1, split-string@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "split-string@npm:3.1.0"
+  dependencies:
+    extend-shallow: "npm:^3.0.0"
+  checksum: 00f7ed7c1fde384dc5ad2c8cc8bec2d7470e707350ef9f4842ec46a6cf493134830f5d34060c474e07263b13789726af1def165cc1f9eccf6a5fa65cabbd1962
+  languageName: node
+  linkType: hard
+
 "split2@npm:^3.0.0":
   version: 3.2.2
   resolution: "split2@npm:3.2.2"
   dependencies:
     readable-stream: "npm:^3.0.0"
   checksum: 686aeb34a25f99fcbc9e1c8b1fe04e45f300dce4951776c765500702e3e412850a6acb812b638e975fd1c96bb6e61218898044a4743f7ac2b4793bc050a63760
+  languageName: node
+  linkType: hard
+
+"ssri@npm:^6.0.1":
+  version: 6.0.2
+  resolution: "ssri@npm:6.0.2"
+  dependencies:
+    figgy-pudding: "npm:^3.5.1"
+  checksum: 8cce511e0cd0da1988bd97fae9b2f17c19515a3e5b6556203d6766ba414446092a2246013fafb41c46354e31ff7bad5af6be8aeb3fb666a929ab9a6f5b1f6b40
+  languageName: node
+  linkType: hard
+
+"ssri@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "ssri@npm:8.0.1"
+  dependencies:
+    minipass: "npm:^3.1.1"
+  checksum: b004b327d00f6ef93089a79c8d5822b991c007438e3134368f9540d89c43614df80461f3ed6273c8d3f30846cdc979e8d35b5ef8a8affb13cff2910cd81bd6be
   languageName: node
   linkType: hard
 
@@ -6807,10 +14528,88 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:~1.5.0":
-  version: 1.5.0
-  resolution: "statuses@npm:1.5.0"
-  checksum: 9d6802be15e8e10700dcb86e2cd7e86eba497e8b7b37db1fe340062bfcb64a63b1e5fa8c3d3737678d87b2d6e3a803023a3a49582b2f66b4fef1df8b5a3ee1e2
+"stable@npm:^0.1.8":
+  version: 0.1.8
+  resolution: "stable@npm:0.1.8"
+  checksum: 1a41cb7ac77e687335090b00469a3c7f6e1cf9c8761278d0778a42290cd2b2ad71213793a4dff5b030e3e9fa0eaa87094fa277cb5df45ed2270136e3aafc6594
+  languageName: node
+  linkType: hard
+
+"stackframe@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "stackframe@npm:1.3.4"
+  checksum: 18e235651352cdc7f0fbe799b92764fd8d28fc516aefd2ff61162233944d10cb37736a94637b431eeef397ec05471635e96555847f5ffe53e488f48e6d365187
+  languageName: node
+  linkType: hard
+
+"state-toggle@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "state-toggle@npm:1.0.3"
+  checksum: 2983e71a969bef6bd99f8990daaf9df9b8960dced0ca0ef10addb07932583f87458488efa4d87e5d9844aef12712f81b6aad8ef7884e61def90ff481a7fa1da5
+  languageName: node
+  linkType: hard
+
+"static-extend@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "static-extend@npm:0.1.2"
+  dependencies:
+    define-property: "npm:^0.2.5"
+    object-copy: "npm:^0.1.0"
+  checksum: 33081dbfbd4600a2cd9dbabb501eccd7f934d0d57c23bf559d546e100fbf4f791e150aa7506577576e2d7892c7da0816eeac074ee0406f42cf502d6d367d875f
+  languageName: node
+  linkType: hard
+
+"statuses@npm:2.0.1":
+  version: 2.0.1
+  resolution: "statuses@npm:2.0.1"
+  checksum: a7e9d41901245a442e77b339f715d77ac113c03ab9434d9f81ae45d75ed3437d9824e601ae1a834ad3e471ae3fc78d3c00decec5e826c91552a58d4c38833ecf
+  languageName: node
+  linkType: hard
+
+"store2@npm:^2.12.0":
+  version: 2.14.2
+  resolution: "store2@npm:2.14.2"
+  checksum: d62cc5a7310be0c063776a45d5509d53092e20df2ff7fe3cdf34d871a980dc5729f1e210074c193aa734f8121c1b37f246b883988f4af9566f2c602dddbabf00
+  languageName: node
+  linkType: hard
+
+"stream-browserify@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "stream-browserify@npm:2.0.2"
+  dependencies:
+    inherits: "npm:~2.0.1"
+    readable-stream: "npm:^2.0.2"
+  checksum: ac2b22347c3135552fdb0a58ceb37e6a1d38d37ffae05cc09645260c7cc77cfb8c019af80359d3fd64e7f9c88d46108a95a347fa7ec9a94d1e25f365cf0e0675
+  languageName: node
+  linkType: hard
+
+"stream-each@npm:^1.1.0":
+  version: 1.2.3
+  resolution: "stream-each@npm:1.2.3"
+  dependencies:
+    end-of-stream: "npm:^1.1.0"
+    stream-shift: "npm:^1.0.0"
+  checksum: 69b38f3074f435430a3b2320a9ca56acec78271b80c11f7984c529f73d0ee079596fa045e9d0215b9a0cd20c3e81b394a2693c8e3ba7fa041cc6b8b8603cb3b3
+  languageName: node
+  linkType: hard
+
+"stream-http@npm:^2.7.2":
+  version: 2.8.3
+  resolution: "stream-http@npm:2.8.3"
+  dependencies:
+    builtin-status-codes: "npm:^3.0.0"
+    inherits: "npm:^2.0.1"
+    readable-stream: "npm:^2.3.6"
+    to-arraybuffer: "npm:^1.0.0"
+    xtend: "npm:^4.0.0"
+  checksum: ed869008b7b17d9a3752ced607485548aa32ca6bea286a48c95fe3b530db02d4cb5b2a8e9018ffe9783b3964699d09a69ffc4550a7686ffb394ae53c882566f6
+  languageName: node
+  linkType: hard
+
+"stream-shift@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "stream-shift@npm:1.0.1"
+  checksum: 078c51f760750e60a20bb9264d4ca6918bedd8a6e1fb474a475699411916606b840f8b4cb5d038f684afc549692475fde16535d73d80dc2f2cec61366211b8d1
   languageName: node
   linkType: hard
 
@@ -6821,7 +14620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.0.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.2, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -6843,7 +14642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string.prototype.matchall@npm:^4.0.7":
+"string.prototype.matchall@npm:^4.0.0 || ^3.0.1, string.prototype.matchall@npm:^4.0.7":
   version: 4.0.7
   resolution: "string.prototype.matchall@npm:4.0.7"
   dependencies:
@@ -6856,6 +14655,28 @@ __metadata:
     regexp.prototype.flags: "npm:^1.4.1"
     side-channel: "npm:^1.0.4"
   checksum: 25347979dc8b8852ef270f2f070b5993d29300d92901bad00d7370f213f60cf2a2e419fc9320c28fbfbaecc9719deffed2834eafacb5595f888c01297b0d948e
+  languageName: node
+  linkType: hard
+
+"string.prototype.padend@npm:^3.0.0":
+  version: 3.1.3
+  resolution: "string.prototype.padend@npm:3.1.3"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.1"
+  checksum: 385048dec65e3a6b92ad0adc060e3bce4498fd3c98fd6525530eeb0907a40f3deaf12748875a0444a0299998ae08429273cf0a3b528c7742f64045d58f35f85b
+  languageName: node
+  linkType: hard
+
+"string.prototype.padstart@npm:^3.0.0":
+  version: 3.1.3
+  resolution: "string.prototype.padstart@npm:3.1.3"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.19.1"
+  checksum: 5b30d0bdf93bfa6499c0376c146f8d5a5e6d0aff75aa086213b3a0286016edefe0635c39da51f540b69e505eac21f2800854b2ccd43a1109f0462795411709ee
   languageName: node
   linkType: hard
 
@@ -6881,12 +14702,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
+"string_decoder@npm:^1.0.0, string_decoder@npm:^1.1.1":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
     safe-buffer: "npm:~5.2.0"
   checksum: c6b892bdb15861a68c4f9599bdff3909c70b1a2cee73d226a235b8fbadfc0aa060bdd265cb3fd86e856cee6d98cd0d657f84098cb51241f4fae19d0cacf9e13e
+  languageName: node
+  linkType: hard
+
+"string_decoder@npm:~1.1.1":
+  version: 1.1.1
+  resolution: "string_decoder@npm:1.1.1"
+  dependencies:
+    safe-buffer: "npm:~5.1.0"
+  checksum: 385c6f229dc54d087d10279049fbc75b0e648dd56ee63dbf15a526975947875fe2b41e0e26addc2e6f2c6e517753a77cfb05338e61d76ac44f49387e7238e025
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "strip-ansi@npm:3.0.1"
+  dependencies:
+    ansi-regex: "npm:^2.0.0"
+  checksum: 9ea89aab5ee05cd6b64bf8c919acf0d7b923d7bbb7a8a678b7b5cfb2b0a92cda18a35e1f16d04c5c00d1eb509c06383687ea2039dd8591ce83b8861602a67114
   languageName: node
   linkType: hard
 
@@ -6908,6 +14747,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-bom@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "strip-bom@npm:2.0.0"
+  dependencies:
+    is-utf8: "npm:^0.2.0"
+  checksum: e1f3e056932a02ed1302aa20e87cadfd3933789e00a10ad6ded932d44acd8972df40fcde899b210e16a72c670d3e7d1ee4e3fa4241f0c1625c8549b1ccc79247
+  languageName: node
+  linkType: hard
+
 "strip-bom@npm:^3.0.0":
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
@@ -6926,6 +14774,17 @@ __metadata:
   version: 3.0.0
   resolution: "strip-final-newline@npm:3.0.0"
   checksum: 0b05a6bdafc591cf7d9eb40b74a976eeb0a65ce03b061436fc55a91e96572e0dd84f02efe24169cd3ec83691c448456370b40a3c852acc45e61af0782a797987
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "strip-indent@npm:1.0.1"
+  dependencies:
+    get-stdin: "npm:^4.0.1"
+  bin:
+    strip-indent: cli.js
+  checksum: 0887ba76aeb3c4bd74b608a6d6d2816f756e884f486b895e37d214c0f1edbec64f0f541b1d265a0186bf7895e37cc98d59e6a52d5fa18c365d8ad621cadecac4
   languageName: node
   linkType: hard
 
@@ -6961,7 +14820,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0":
+"style-loader@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "style-loader@npm:1.3.0"
+  dependencies:
+    loader-utils: "npm:^2.0.0"
+    schema-utils: "npm:^2.7.0"
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 1fb36c8d9dc65b985a4904a8970119062792f2f578bb182ef681f4df09110bc103108a52222b96655bfd03e626af8d36888701bb13fded2e6efa4707731b5507
+  languageName: node
+  linkType: hard
+
+"style-to-object@npm:0.3.0, style-to-object@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "style-to-object@npm:0.3.0"
+  dependencies:
+    inline-style-parser: "npm:0.1.1"
+  checksum: ffd915079324b072842ef44ef2063cee963fc4f43f12dbbb8678311ac529b280cfe21a3bb2db59154a590c223d8d86ed8906eeb3b983a303ff3f187aa04cd9cd
+  languageName: node
+  linkType: hard
+
+"styled-components@npm:5.3.5":
+  version: 5.3.5
+  resolution: "styled-components@npm:5.3.5"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.0.0"
+    "@babel/traverse": "npm:^7.4.5"
+    "@emotion/is-prop-valid": "npm:^1.1.0"
+    "@emotion/stylis": "npm:^0.8.4"
+    "@emotion/unitless": "npm:^0.7.4"
+    babel-plugin-styled-components: "npm:>= 1.12.0"
+    css-to-react-native: "npm:^3.0.0"
+    hoist-non-react-statics: "npm:^3.0.0"
+    shallowequal: "npm:^1.1.0"
+    supports-color: "npm:^5.5.0"
+  peerDependencies:
+    react: ">= 16.8.0"
+    react-dom: ">= 16.8.0"
+    react-is: ">= 16.8.0"
+  checksum: f74a33b2597ad9ddd6233ca2afccc9462a74daa8cb16a44b5e9ca2628e0966587be2f94a1376ef75d75db717faf5e8d042e1a0b2e2b6b7ce10116c26050342f5
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:
@@ -6970,12 +14872,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.1.0":
+"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 9218cc0d12c57f4ae213e6ace98e0cda2d8f47617300f21501a0078e17d9e3b4aa3effdc1006e369dfd5389ff4f99682b9617d4a8fb7566e2964955dd14d4cc3
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^8.0.0":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 3fe58a405502d866f7611fe1926cac2410d6aac87658b3aac94b70617576586270d2ec758ae975ca3ba20556a1c013330c820b59a85f983d322a47cd28118b2c
   languageName: node
   linkType: hard
 
@@ -6986,14 +14897,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svg-parser@npm:^2.0.2":
-  version: 2.0.4
-  resolution: "svg-parser@npm:2.0.4"
-  checksum: b970f4533a6ce64d3498f1a2c87d0cfd6d681e18fa58af7a9b061119dbb968e289a650e2c2094f08e28e83b9727a857545e7e15f6b27b2426f3c32cfa7f1a941
+"symbol.prototype.description@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "symbol.prototype.description@npm:1.0.5"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    get-symbol-description: "npm:^1.0.0"
+    has-symbols: "npm:^1.0.2"
+    object.getownpropertydescriptors: "npm:^2.1.2"
+  checksum: d5d2e1d37cf74592444a567795bb7c28fb2569f2baa2b298402bfe8a050dee09c02ab6543fbe2def9c41cd79db99e8076cb7a3a50ac66ea30174d2be715091bf
   languageName: node
   linkType: hard
 
-"tar@npm:^6.1.11, tar@npm:^6.1.2":
+"synchronous-promise@npm:^2.0.15":
+  version: 2.0.15
+  resolution: "synchronous-promise@npm:2.0.15"
+  checksum: b596073c275548fc658da97e924beefb5103918d4e122b159809f52b9a2384778b63c2e9b6396d9e2da8cfba63a75b4fe268549a801d1062101232ea310ad5b7
+  languageName: node
+  linkType: hard
+
+"tapable@npm:^1.0.0, tapable@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "tapable@npm:1.1.3"
+  checksum: 988a1f4fa6e07895b39f149d65a01686967d4723341b7b3a906aff1117a30295eb106b3f395fa8e066db199fa69385c57136509c7750f803043420f981363a9d
+  languageName: node
+  linkType: hard
+
+"tapable@npm:^2.1.1, tapable@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "tapable@npm:2.2.1"
+  checksum: d54320ef41e04b13e27e20bfc355bd27bccb4b1ac28123a35d36d903b393944a957a7629b56e808e1a2ef03dcaf1c114e97de7a1b7cbf16e522cd0630219702e
+  languageName: node
+  linkType: hard
+
+"tar@npm:^6.0.2, tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.1.11
   resolution: "tar@npm:6.1.11"
   dependencies:
@@ -7004,6 +14941,120 @@ __metadata:
     mkdirp: "npm:^1.0.3"
     yallist: "npm:^4.0.0"
   checksum: 5499de6e1998ca602c327f3359d085f6ab41e63a0ce530fb15de13089d3795262b6dfb7731989b7e1d0289a76658d715d8e1239fc06f70ae49349205e3a5fbcc
+  languageName: node
+  linkType: hard
+
+"telejson@npm:6.0.8, telejson@npm:^6.0.8":
+  version: 6.0.8
+  resolution: "telejson@npm:6.0.8"
+  dependencies:
+    "@types/is-function": "npm:^1.0.0"
+    global: "npm:^4.4.0"
+    is-function: "npm:^1.0.2"
+    is-regex: "npm:^1.1.2"
+    is-symbol: "npm:^1.0.3"
+    isobject: "npm:^4.0.0"
+    lodash: "npm:^4.17.21"
+    memoizerific: "npm:^1.11.3"
+  checksum: 57a261e15245582505acc8e47d4b36b943657724f28d5e5a5898eaad613aea5265211d82413fcadfb9ed350f5308b069eddec44020029d134103fa8dcb26f813
+  languageName: node
+  linkType: hard
+
+"terser-webpack-plugin@npm:^1.4.3":
+  version: 1.4.5
+  resolution: "terser-webpack-plugin@npm:1.4.5"
+  dependencies:
+    cacache: "npm:^12.0.2"
+    find-cache-dir: "npm:^2.1.0"
+    is-wsl: "npm:^1.1.0"
+    schema-utils: "npm:^1.0.0"
+    serialize-javascript: "npm:^4.0.0"
+    source-map: "npm:^0.6.1"
+    terser: "npm:^4.1.2"
+    webpack-sources: "npm:^1.4.0"
+    worker-farm: "npm:^1.7.0"
+  peerDependencies:
+    webpack: ^4.0.0
+  checksum: a674ebfc10feb39768ae6e3a69fa40fc3e16340caf09576bdd2f9be8cc47d5e2e43ee0a9b86562c97ae4ea6fc5c9a168019dbac9fb803cfb13a75645add2c657
+  languageName: node
+  linkType: hard
+
+"terser-webpack-plugin@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "terser-webpack-plugin@npm:4.2.3"
+  dependencies:
+    cacache: "npm:^15.0.5"
+    find-cache-dir: "npm:^3.3.1"
+    jest-worker: "npm:^26.5.0"
+    p-limit: "npm:^3.0.2"
+    schema-utils: "npm:^3.0.0"
+    serialize-javascript: "npm:^5.0.1"
+    source-map: "npm:^0.6.1"
+    terser: "npm:^5.3.4"
+    webpack-sources: "npm:^1.4.3"
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: b1b76bb6d7e8651b6302a30592670dc7765a0cd7c60e0de2cdd0e09d7733143b8088c08bf4614acd105511fd20ae09ed877760183447a9b3bd00bf6095defb89
+  languageName: node
+  linkType: hard
+
+"terser-webpack-plugin@npm:^5.1.3":
+  version: 5.3.3
+  resolution: "terser-webpack-plugin@npm:5.3.3"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.7"
+    jest-worker: "npm:^27.4.5"
+    schema-utils: "npm:^3.1.1"
+    serialize-javascript: "npm:^6.0.0"
+    terser: "npm:^5.7.2"
+  peerDependencies:
+    webpack: ^5.1.0
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    esbuild:
+      optional: true
+    uglify-js:
+      optional: true
+  checksum: 375428be9fed4791cc920fe98301101bf6a1da57e6a6f15963dede94f9c250959e29da2f858e2a9ff54c4a3dd938bd4bc8842d5cb303f62ae2b61c8104a2507c
+  languageName: node
+  linkType: hard
+
+"terser@npm:^4.1.2, terser@npm:^4.6.3":
+  version: 4.8.1
+  resolution: "terser@npm:4.8.1"
+  dependencies:
+    commander: "npm:^2.20.0"
+    source-map: "npm:~0.6.1"
+    source-map-support: "npm:~0.5.12"
+  bin:
+    terser: bin/terser
+  checksum: b5c36dc05006610457299d18b40cabfb352d2fd51528d8d1ca4576140ea9a27fa55edcc521d76b5feda2d443adf388ba4c3d64d42ce329e19fb2a8c1464d50a3
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.3.4, terser@npm:^5.7.2":
+  version: 5.14.2
+  resolution: "terser@npm:5.14.2"
+  dependencies:
+    "@jridgewell/source-map": "npm:^0.3.2"
+    acorn: "npm:^8.5.0"
+    commander: "npm:^2.20.0"
+    source-map-support: "npm:~0.5.20"
+  bin:
+    terser: bin/terser
+  checksum: d704a8df5e9a4b866e8416af4fd2dd060051ed8060d0b484658e10df470a9c0497f6e69126d56dd59655d247412fdd808611eac320c67301a2863766fb602167
+  languageName: node
+  linkType: hard
+
+"test-exclude@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "test-exclude@npm:6.0.0"
+  dependencies:
+    "@istanbuljs/schema": "npm:^0.1.2"
+    glob: "npm:^7.1.4"
+    minimatch: "npm:^3.0.4"
+  checksum: bcb7eecb486d1441f2c55a05d079f72e2e13e74c8e89051412e33382e745996d646036a7d13d3a74c60222f59dd48c5b8cc83c1f3b5647332262d9c5f04da937
   languageName: node
   linkType: hard
 
@@ -7018,6 +15069,16 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: 65e9ab9cd26946c5378cd4b8782562f47e017bad4fe8d398356380fdc762d08b177ca6a1c5c8deac14fbe974c46cd09c0cbb86560545cfa49800f3fcacb0c952
+  languageName: node
+  linkType: hard
+
+"through2@npm:^2.0.0":
+  version: 2.0.5
+  resolution: "through2@npm:2.0.5"
+  dependencies:
+    readable-stream: "npm:~2.3.6"
+    xtend: "npm:~4.0.1"
+  checksum: d3858dcef8a86805319d8022e5b87d3ee91c983250bd1a1771f354b9181ce33e06d0f9c1635d2fbc1a017b22f893a23db50d6053fa2933042f4c022bf0195f14
   languageName: node
   linkType: hard
 
@@ -7037,6 +15098,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"timers-browserify@npm:^2.0.4":
+  version: 2.0.12
+  resolution: "timers-browserify@npm:2.0.12"
+  dependencies:
+    setimmediate: "npm:^1.0.4"
+  checksum: b036229806af6c15b03c8d491b9e1853b336dfc9f45a3dab82d98aeeb95385cf495a3e1c00463a073f7159a4101f271c3938dd5a1bb056cac8df3f069f5f6ecb
+  languageName: node
+  linkType: hard
+
 "tinypool@npm:^0.2.4":
   version: 0.2.4
   resolution: "tinypool@npm:0.2.4"
@@ -7051,10 +15121,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"to-arraybuffer@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "to-arraybuffer@npm:1.0.1"
+  checksum: 51df260b300e8fed22788db6d833de765b09d19c84977e02e9563cccb414a7cbb3e8b57b0932823db00201dd94cc0fcba0ba67d76adb80cf3af6213f60104a36
+  languageName: node
+  linkType: hard
+
 "to-fast-properties@npm:^2.0.0":
   version: 2.0.0
   resolution: "to-fast-properties@npm:2.0.0"
   checksum: 49d863a314830916634c1a28911db62be419b93fbc430c18955584f112d0e20ccd078c319c5a9af077e11bbf42cdcd8405726262bfb2d4db9fe91ae9f5585ed2
+  languageName: node
+  linkType: hard
+
+"to-object-path@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "to-object-path@npm:0.3.0"
+  dependencies:
+    kind-of: "npm:^3.0.2"
+  checksum: 9ba07c02471b80b1d9a6f6b8a6f7f67523d6a163e5d875c1a7517ac9ba06163f630e29b4bd7970270ba4343352c4933ff43755906aed3d1100799c28f17d3089
+  languageName: node
+  linkType: hard
+
+"to-regex-range@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "to-regex-range@npm:2.1.1"
+  dependencies:
+    is-number: "npm:^3.0.0"
+    repeat-string: "npm:^1.6.1"
+  checksum: 0bd7383a3afc95e52d7b480945525df3f99c5e0c8921ef8bc102de4324d374940d7ff3cd12e0792e7ceeb80a77f4fc3dadab834369484cc3ad2a211d117c07c7
   languageName: node
   linkType: hard
 
@@ -7064,6 +15160,25 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 16564897c76bbd25bd3c375ee8d4b1fd3ac965fc4ab550ff034a1dddb53816ec06dc27095468394ad4de5978d5e831a9d1ae4cb31080dc4ebd9ba80a47dc1a4f
+  languageName: node
+  linkType: hard
+
+"to-regex@npm:^3.0.1, to-regex@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "to-regex@npm:3.0.2"
+  dependencies:
+    define-property: "npm:^2.0.2"
+    extend-shallow: "npm:^3.0.2"
+    regex-not: "npm:^1.0.2"
+    safe-regex: "npm:^1.1.0"
+  checksum: c1fa63f38c3fcfb9b5c0a50ca57cb29e46069ffd4428b6e32ad20e60b0c7af5dc8044641a554ad0a50ba9f262aacf9f9a3c290bdccb7c0bc0d47fc484f2a1c5b
+  languageName: node
+  linkType: hard
+
+"toidentifier@npm:1.0.1":
+  version: 1.0.1
+  resolution: "toidentifier@npm:1.0.1"
+  checksum: ed889234ceb442c0d5f87ab3f2a8fc0679800baa41766c0d9ce1bb82c700052fd6cf5d1656e1304de13d7a7d5974962fedc1bbe9a0e4686c3d8743c716c7dd5f
   languageName: node
   linkType: hard
 
@@ -7109,6 +15224,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"trim-newlines@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "trim-newlines@npm:1.0.0"
+  checksum: 7cb96832c99fb14986ba329e29c84edfcf878a10129d68efc6db147ac6ac14b91bc249b6b7685152e325e01ac6a1577dcd5342c0ad627bbba62cdc5dc98ae6e7
+  languageName: node
+  linkType: hard
+
 "trim-newlines@npm:^3.0.0":
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
@@ -7123,7 +15245,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-dedent@npm:2.2.0":
+"trim-trailing-lines@npm:^1.0.0":
+  version: 1.1.4
+  resolution: "trim-trailing-lines@npm:1.1.4"
+  checksum: f1a874f0cb9ef49755cb6c2187648ceccfcb56232d06090b65ba7158298002e76cf276e837a0734053738df1f67ad1650586780cad5ba994d78b294799a74499
+  languageName: node
+  linkType: hard
+
+"trim@npm:0.0.1":
+  version: 0.0.1
+  resolution: "trim@npm:0.0.1"
+  checksum: a4e00610a6f83008dfc6cd49f3d7f0150f67aab91e0c80ec8cc46640e8ffe7a008af14e1f66c38ab6294acdc4802b84fe2c00f64021ca8f092528b5f5f7a3a46
+  languageName: node
+  linkType: hard
+
+"trough@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "trough@npm:1.0.5"
+  checksum: e32c4797a9b920a038c639d0e378579d0f18d087a7603323cbd25eff880b9d19f4e20e10aecedf629ef24446b6ffb3189b6cdfeba669902ca969e0c77eecb2b9
+  languageName: node
+  linkType: hard
+
+"ts-dedent@npm:2.2.0, ts-dedent@npm:^2.0.0":
   version: 2.2.0
   resolution: "ts-dedent@npm:2.2.0"
   checksum: 66108854b96437960b939db641dc563eb06c72d441e4a6f874b18075fce95b4d70bd7b7b6531324708350700701ed5fcba1e395718ddf2d5fbbb58e89d289c76
@@ -7168,6 +15311,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-pnp@npm:^1.1.6":
+  version: 1.2.0
+  resolution: "ts-pnp@npm:1.2.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: a3b2c6a980d3bfe28e32a8511607784d9b09c08004bc2cadddd92da2a7220520599130c923217a048b09bd8db912ffbd6d9f0bcd8e4071b08a71c244b9d2d164
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:4.0.0, tsconfig-paths@npm:^4.0.0":
   version: 4.0.0
   resolution: "tsconfig-paths@npm:4.0.0"
@@ -7198,7 +15351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 022a70708abbc3491734959effd9a87e6e0af5932b61d0c9f1d07b8b80cabbbfc9fc9e9c0fe86e5ab2d32d766ae30117edf00b02d170ff255ab7e60361a4b711
@@ -7216,6 +15369,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tty-browserify@npm:0.0.0":
+  version: 0.0.0
+  resolution: "tty-browserify@npm:0.0.0"
+  checksum: 1926c00568bab00806ca940dffdb10f0397625d61fd6a51536b854665caeec8b912ff46665f08f28c1e88d23c5a65cb86017e987abb62ebdc4e7b6c09cd7df6d
+  languageName: node
+  linkType: hard
+
 "tunnel@npm:^0.0.6":
   version: 0.0.6
   resolution: "tunnel@npm:0.0.6"
@@ -7229,6 +15389,15 @@ __metadata:
   dependencies:
     prelude-ls: "npm:^1.2.1"
   checksum: 20afe001f1e32be931a04d1ae0529cf48e5e848cc89bb5a98904481916aa04fb4aa61e795cd94dad4f9b8daf7024bc97b90ac7f24885f0797c3f3c0a096bbece
+  languageName: node
+  linkType: hard
+
+"type-check@npm:~0.3.2":
+  version: 0.3.2
+  resolution: "type-check@npm:0.3.2"
+  dependencies:
+    prelude-ls: "npm:~1.1.2"
+  checksum: 92c9d1306c41f84ebc2af6f53326c59c6ed1d3c6a89d5c8a8ec20ef959af135d97b8f0f0773137bd50dd54098b5742f76129141a4519cd77b5f38517cf3637b2
   languageName: node
   linkType: hard
 
@@ -7281,12 +15450,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-is@npm:~1.6.18":
+  version: 1.6.18
+  resolution: "type-is@npm:1.6.18"
+  dependencies:
+    media-typer: "npm:0.3.0"
+    mime-types: "npm:~2.1.24"
+  checksum: 1cf58e1d0c2129201bee6abe8029f5dda621f86a1094955b6510c9baf879a45f725b2e19c7dc1f04a623a0edd8f3cc39cc4d4899287c805b6b1177c961f46564
+  languageName: node
+  linkType: hard
+
 "typedarray-to-buffer@npm:^3.1.5":
   version: 3.1.5
   resolution: "typedarray-to-buffer@npm:3.1.5"
   dependencies:
     is-typedarray: "npm:^1.0.0"
   checksum: 77dee0df8aedfbe8916f6a6a06d720ff15c5846ee6f1d7097a5421906a3d99be61cd93099de4fb93bc7a6f9b7e9bcb7d25b7c7a71a5f63d00dae2f222f7a5d9d
+  languageName: node
+  linkType: hard
+
+"typedarray@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "typedarray@npm:0.0.6"
+  checksum: b0b2ee8d06d5827891346d2db9929fdbd2f719ef5b55afed90f5e48b36fc49df0f8280daf362a05b3d971972e13779011dd501b5a53bd36f938ae88f6b8552cb
   languageName: node
   linkType: hard
 
@@ -7321,6 +15507,15 @@ __metadata:
   version: 0.8.5
   resolution: "ufo@npm:0.8.5"
   checksum: 07eee1ce96b4881ce4a59bda8155ad2584633bf10cb79e3b2e701955ee4ff866c26ef604514f6d19e190f426b18e84e53bb5058f6778f2dfc298536c520b4aff
+  languageName: node
+  linkType: hard
+
+"uglify-js@npm:^3.1.4":
+  version: 3.16.3
+  resolution: "uglify-js@npm:3.16.3"
+  bin:
+    uglifyjs: bin/uglifyjs
+  checksum: bfa484b42c31c8e114dfd4579fcc075c7bd3dfebdf277cbf6905199f6cfc7763090d02ab703bf16e2160090eded72b7fa979e1ea85611f4cbd3ec61f318840f1
   languageName: node
   linkType: hard
 
@@ -7373,6 +15568,80 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unfetch@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "unfetch@npm:4.2.0"
+  checksum: d6cba4481ab35caf314be504ca2f97247a3f75b48771631ad32f29fa4285a00201e6b69094d00027bd7560f5523e9153840d659807a6879e95eef27105641053
+  languageName: node
+  linkType: hard
+
+"unherit@npm:^1.0.4":
+  version: 1.1.3
+  resolution: "unherit@npm:1.1.3"
+  dependencies:
+    inherits: "npm:^2.0.0"
+    xtend: "npm:^4.0.0"
+  checksum: 192073359af6668ef1f0dbca510a83762474ef88f63c82ed600f2c984e6690c0839bf8656e3cb887051064ad35bf1c84543bac248986ada378ee685030f55c75
+  languageName: node
+  linkType: hard
+
+"unicode-canonical-property-names-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.0"
+  checksum: 47e911d5e1d402ca900065fff87a02135ff25912ba685bf62baf32882db30167ab11bfcb2505d9d6ca494c7e1b056d66aefb21a4c2479b9772133776938dead2
+  languageName: node
+  linkType: hard
+
+"unicode-match-property-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-match-property-ecmascript@npm:2.0.0"
+  dependencies:
+    unicode-canonical-property-names-ecmascript: "npm:^2.0.0"
+    unicode-property-aliases-ecmascript: "npm:^2.0.0"
+  checksum: 1f153bf35cb44e664e230214d0dbfca9209125ec4a7097ad7771efd44497fa183d3d3e70ce625d0af42c2f0f37ccc70b18c6ad1d3465dd4c3bab5cb1a2206b6a
+  languageName: node
+  linkType: hard
+
+"unicode-match-property-value-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-match-property-value-ecmascript@npm:2.0.0"
+  checksum: 8b5ce98e39c6cd30ce1b150916135103fd0e541c9b08bb718a1fe8c4981c6d27ae43fd808476b963bceb2678f805e43ef1eceac24c58d91f91a3dace27ae4ba3
+  languageName: node
+  linkType: hard
+
+"unicode-property-aliases-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-property-aliases-ecmascript@npm:2.0.0"
+  checksum: 3e123410a4399a1e45390a0ef546d15e18d2d5c722e478414232291e69b732cf5cca70ba90e9b4a45fc9ce39b6afc776fddff26ec6b1533cc459d1363e1243f7
+  languageName: node
+  linkType: hard
+
+"unified@npm:9.2.0":
+  version: 9.2.0
+  resolution: "unified@npm:9.2.0"
+  dependencies:
+    bail: "npm:^1.0.0"
+    extend: "npm:^3.0.0"
+    is-buffer: "npm:^2.0.0"
+    is-plain-obj: "npm:^2.0.0"
+    trough: "npm:^1.0.0"
+    vfile: "npm:^4.0.0"
+  checksum: 177ecc5987ab8463b2083c67acea532a10cddb92f8eac5881d37e5aaf6a02324b8d13ff779ae05f8122884eb869966187dc9eabc929e87fcd9a3701c4ca70452
+  languageName: node
+  linkType: hard
+
+"union-value@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "union-value@npm:1.0.1"
+  dependencies:
+    arr-union: "npm:^3.1.0"
+    get-value: "npm:^2.0.6"
+    is-extendable: "npm:^0.1.1"
+    set-value: "npm:^2.0.1"
+  checksum: 22551b59265711bc6df4852c6cf1dd463d46c18ed3ba6cc867c0b92258065f4d81176894c8c42342c67e947c880979ff24e4f83ca929a09db8885ea9dbaddb0b
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^1.1.1":
   version: 1.1.1
   resolution: "unique-filename@npm:1.1.1"
@@ -7400,12 +15669,79 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-builder@npm:2.0.3, unist-builder@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "unist-builder@npm:2.0.3"
+  checksum: 4f20f6b2a0e5e06356ae66fa5e14d150b2d1397e4b568d26d42122c936b946b96c6f81e7fc69525843fb7db85a2cea154f21877174e09eff672c83af2dcf88af
+  languageName: node
+  linkType: hard
+
+"unist-util-generated@npm:^1.0.0":
+  version: 1.1.6
+  resolution: "unist-util-generated@npm:1.1.6"
+  checksum: 0706ee44162e8501381cdafb0aea9c1925023da45f76c160465c490bb0bd9cac5933b8bfac63262a2a30d5d472ae6019f18316fb99e8660e261e2b6077ef1eea
+  languageName: node
+  linkType: hard
+
+"unist-util-is@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "unist-util-is@npm:4.1.0"
+  checksum: d4ff96f0f3d844d2363b0ded2d84b927026bde15ccce049fe09541c28196fd7c4f57f60adbc134947126d3d0ffa040e94966b705ac22c334665c523b4a0dbaba
+  languageName: node
+  linkType: hard
+
+"unist-util-position@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "unist-util-position@npm:3.1.0"
+  checksum: b35a381dfca55332a6e29b975f07447f09b45aea91efae600d954b59ad6aaa150beb623d81aaae9c7ef05e20b6f9fb164e19c018f31ad443ed931bec2911cad9
+  languageName: node
+  linkType: hard
+
+"unist-util-remove-position@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "unist-util-remove-position@npm:2.0.1"
+  dependencies:
+    unist-util-visit: "npm:^2.0.0"
+  checksum: fda1d1137e9ba0d1cb249f1bc157b5d4a6c10e355b1f206a604564b2e4ca1a6adf3bcdb741cd6d42788d00cd6a0bffa034360f96e9337756a0a0bcab968e7f73
+  languageName: node
+  linkType: hard
+
+"unist-util-remove@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "unist-util-remove@npm:2.1.0"
+  dependencies:
+    unist-util-is: "npm:^4.0.0"
+  checksum: ffac06643addf9a4110c2b70c1a0dc5b346c356a0613ff6e9560b811914b1da22964429f05279cc096d424ad1a1960d25c2f760ae2e33699a6270073ce08ec74
+  languageName: node
+  linkType: hard
+
 "unist-util-stringify-position@npm:^2.0.0":
   version: 2.0.3
   resolution: "unist-util-stringify-position@npm:2.0.3"
   dependencies:
     "@types/unist": "npm:^2.0.2"
   checksum: 683882c0b9e07db85f9ff90a452a73623b00623c06f87b5347ab7706844da375eb7d58704f54129e1adb7bdf91549f95a23208b9b87593a06d8c3c4e60d1f155
+  languageName: node
+  linkType: hard
+
+"unist-util-visit-parents@npm:^3.0.0":
+  version: 3.1.1
+  resolution: "unist-util-visit-parents@npm:3.1.1"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    unist-util-is: "npm:^4.0.0"
+  checksum: 289df6544a2d2d5d30f72ab04b37ae44f03a9b371c613d2689953c8240ecacd01c71c5fbcab48aed904d788792607915ec31088ce009e53092345e7735ae0a78
+  languageName: node
+  linkType: hard
+
+"unist-util-visit@npm:2.0.3, unist-util-visit@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "unist-util-visit@npm:2.0.3"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    unist-util-is: "npm:^4.0.0"
+    unist-util-visit-parents: "npm:^3.0.0"
+  checksum: 275db95a965d5e4edb800d5c3e6201e3871abc5e4b30fc44a295f477923703905c875ebb2a5758b6afa45101f5bdb2d296d312dd835bed753f1cf53479b0480a
   languageName: node
   linkType: hard
 
@@ -7416,10 +15752,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unpipe@npm:~1.0.0":
+"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 0504c357ea2fced264cd144bb1c3e44515a22ea8003eb3c35d3dabcb67181b023febec6bfa6fc6d863877bc556ae5939ede1c26d81a7dfd4a8f06b16bd091ea5
+  languageName: node
+  linkType: hard
+
+"unset-value@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "unset-value@npm:1.0.0"
+  dependencies:
+    has-value: "npm:^0.3.1"
+    isobject: "npm:^3.0.0"
+  checksum: cba24229fd6400ebe89d2ab14d81f6cfd6d373977ec5986e9acf3cdfd88c7400b57b652d0806dccfbe446395f8ba19b6715ecf79623b619477cd815e82aed255
+  languageName: node
+  linkType: hard
+
+"untildify@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "untildify@npm:2.1.0"
+  dependencies:
+    os-homedir: "npm:^1.0.0"
+  checksum: bec52c5f17840a86d9905ea97ade2fd6d5ebb8f0ce044a4c47bae952fb8683a2d68ee2d6573608e39adc387db82e793f800f92c3f186846214a5ad4c204a58b9
   languageName: node
   linkType: hard
 
@@ -7435,7 +15790,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.0.4":
+"upath@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "upath@npm:1.2.0"
+  checksum: d4bc0a9ff874fb80c2a7b666791f9680a8169a49a6592662123030cbc969c99136f9962097eaf502de74572a01c84e65f1f4e120190820bc8a9ac8691b77e1d1
+  languageName: node
+  linkType: hard
+
+"update-browserslist-db@npm:^1.0.5":
   version: 1.0.5
   resolution: "update-browserslist-db@npm:1.0.5"
   dependencies:
@@ -7458,6 +15820,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"urix@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "urix@npm:0.1.0"
+  checksum: fce8b11acd7569e826177f36ce9a9db2f4a6a85477874219e01fd132701d3e022eeaa9e760ab10d7cd6f4245c752a5d3fb6483635016bd99aac40c2cd6de01fa
+  languageName: node
+  linkType: hard
+
+"url-loader@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "url-loader@npm:4.1.1"
+  dependencies:
+    loader-utils: "npm:^2.0.0"
+    mime-types: "npm:^2.1.27"
+    schema-utils: "npm:^3.0.0"
+  peerDependencies:
+    file-loader: "*"
+    webpack: ^4.0.0 || ^5.0.0
+  peerDependenciesMeta:
+    file-loader:
+      optional: true
+  checksum: 1a4b8862d3caa029a017387d0d14ec49c4b328a6eb435b59e58dbc7eb0bb9cbf8f3dc17c36c4489b853f93a67c1c6e655dc7735ed423cbe201dd00ba2aa11c74
+  languageName: node
+  linkType: hard
+
+"url@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "url@npm:0.11.0"
+  dependencies:
+    punycode: "npm:1.3.2"
+    querystring: "npm:0.2.0"
+  checksum: faa2280706858e1223e032eee89a43c832fe95803d9917f5b48a82a92fb8eec5556811fc6acb6d7c90ced0adb36d59331a55df86a27320c21bddd24f24600d3b
+  languageName: node
+  linkType: hard
+
+"use@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "use@npm:3.1.1"
+  checksum: 074e49acecdd9f6f094fc9d6e37e8e72a4bbbd904783ec8dc666b8b34aeb0c2cb846094cf241165263e81fa2bb75cb194fe01db372feb7ff504e7b9ffc7f893c
+  languageName: node
+  linkType: hard
+
 "user-home@npm:^2.0.0":
   version: 2.0.0
   resolution: "user-home@npm:2.0.0"
@@ -7467,10 +15870,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1":
+"util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 6a88ed8344d07f2324b304ee36def365d967953b5a9c15baa3213eb3909e86a7da1ee70a4c2133e80c23d6c1987590e9c3c57d874e20a124f9e41620b462fa57
+  languageName: node
+  linkType: hard
+
+"util.promisify@npm:1.0.0":
+  version: 1.0.0
+  resolution: "util.promisify@npm:1.0.0"
+  dependencies:
+    define-properties: "npm:^1.1.2"
+    object.getownpropertydescriptors: "npm:^2.0.3"
+  checksum: 55339d996e259280f2c4ffaac2e6c770f954d2a842688e0fa9b6179bdbcae20ebad2934e19df59fe54909b089707c74fe45b8e5fa1a4227ef81f61a2e6321b88
+  languageName: node
+  linkType: hard
+
+"util@npm:0.10.3":
+  version: 0.10.3
+  resolution: "util@npm:0.10.3"
+  dependencies:
+    inherits: "npm:2.0.1"
+  checksum: 6e8b0eef08f8c7ea977211c5d40d61c6ce731c965ccddf37767007af0750228f77b9f936dd6c435f5628dd2e54a4d6e1055b74e016a5a07ae97814194eb56fc1
+  languageName: node
+  linkType: hard
+
+"util@npm:^0.11.0":
+  version: 0.11.1
+  resolution: "util@npm:0.11.1"
+  dependencies:
+    inherits: "npm:2.0.3"
+  checksum: 44c8f395b72817db97c9e638a06a25b81345a03c6a9a4b44bd1aef9c039e37de91986e6728a1f343c98d21aa859a8a1f32b043600060fda97999172dc3bb67b9
+  languageName: node
+  linkType: hard
+
+"utila@npm:~0.4":
+  version: 0.4.0
+  resolution: "utila@npm:0.4.0"
+  checksum: e2aa07a8028f0c6844101e514032fedc14bc81c45c88d1fb5a3d4333aded5ac484775bd9658b2b0ce016fae1f4dab7736d5dda8134850fbf014ef7e9da59c5bc
   languageName: node
   linkType: hard
 
@@ -7478,6 +15916,15 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: b72b8d7a0f7d63a9b1ced39a44b292994111c93cf9c4da8a561e4fe0d0232af7217a53d5aae3a950fb7ab6f423baf3e0d2d7c7c33dd6c4ec78d0a3c720ee6adb
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^3.3.2":
+  version: 3.4.0
+  resolution: "uuid@npm:3.4.0"
+  bin:
+    uuid: ./bin/uuid
+  checksum: c84dbfcb94389fea5a09020802df2a1227d183ceabaa5256658194dfad045c83fe72366b64b165b6445a480fac8a75d0e982033f3cb393713674b3cd938063fa
   languageName: node
   linkType: hard
 
@@ -7504,6 +15951,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"v8-to-istanbul@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "v8-to-istanbul@npm:9.0.1"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.12"
+    "@types/istanbul-lib-coverage": "npm:^2.0.1"
+    convert-source-map: "npm:^1.6.0"
+  checksum: 06027f6004c45b08c690bc3dc35f3c6efa9ab99f689d4bb275f2b3239400ef084771e3a14960117e38a335b5dfbeaf808db1e4487077a27888c7abd70c42f185
+  languageName: node
+  linkType: hard
+
 "validate-npm-package-license@npm:^3.0.1":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
@@ -7511,6 +15969,42 @@ __metadata:
     spdx-correct: "npm:^3.0.0"
     spdx-expression-parse: "npm:^3.0.0"
   checksum: 6d62b39e947077e554dfdf6a760fb52e8db73e7724aeeab1a1f4aa742e75b2ca5092b9f7b1b9171778e96f592628932ee07784a2c86f4152411180a32a8824be
+  languageName: node
+  linkType: hard
+
+"vary@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "vary@npm:1.1.2"
+  checksum: b1db20d4be443aec48b8efab73386f83d947b7033b6b2f5a0c7ba4a1f9bc0200cb4cb396712468761f8edfe48dd68a6fdee7c65689b90937a2d767c714d25883
+  languageName: node
+  linkType: hard
+
+"vfile-location@npm:^3.0.0, vfile-location@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "vfile-location@npm:3.2.0"
+  checksum: 7fd39df982ab5ae03c00f7ebc98f442b2dfa24ae276ddd82ce79c1178a58445d211c9c968864f7a394f6f308955fe1d44ab38c4d51316d58e873ca7d071a67f6
+  languageName: node
+  linkType: hard
+
+"vfile-message@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "vfile-message@npm:2.0.4"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^2.0.0"
+  checksum: 7c82a443596a0acd22db6b7b6131b5837ed35a017e8b0842a8b6d7fe9ae5643e3c3d38f761a1c9943e1bc85af9a9737d89e1d76208803769f167b75c066d7311
+  languageName: node
+  linkType: hard
+
+"vfile@npm:^4.0.0":
+  version: 4.2.1
+  resolution: "vfile@npm:4.2.1"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    is-buffer: "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^2.0.0"
+    vfile-message: "npm:^2.0.0"
+  checksum: a806da53daba33873d92c6ab79add0a27030ccf46e95692692e910aabdf7dbcea29bc53c44f7252184bf6e081faba24d8b3b0d47b4ffb2cb6ec80b8de8a04892
   languageName: node
   linkType: hard
 
@@ -7529,7 +16023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-tsconfig-paths@npm:3.5.0, vite-tsconfig-paths@npm:^3.3.13":
+"vite-tsconfig-paths@npm:3.5.0":
   version: 3.5.0
   resolution: "vite-tsconfig-paths@npm:3.5.0"
   dependencies:
@@ -7572,74 +16066,6 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 14956d8d355b2ec60925c9b94699640cd81e331209ca9bedd1659a93810c505fd263424fa8998168b6bc6e32375b6be17ad15ed4817847a7bcbc497bfd86205a
-  languageName: node
-  linkType: hard
-
-"vite@npm:^2.5.1":
-  version: 2.9.14
-  resolution: "vite@npm:2.9.14"
-  dependencies:
-    esbuild: "npm:^0.14.27"
-    fsevents: "npm:~2.3.2"
-    postcss: "npm:^8.4.13"
-    resolve: "npm:^1.22.0"
-    rollup: "npm:^2.59.0"
-  peerDependencies:
-    less: "*"
-    sass: "*"
-    stylus: "*"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    less:
-      optional: true
-    sass:
-      optional: true
-    stylus:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 7e333851681ac58e9b510b6eed95ba293e7e08b28e95aa7c2a4d5c8e65e01f9dfc4c39c24496dcd39a949cc82a13cfe13b9065ce84418090e20dbdce08c5a741
-  languageName: node
-  linkType: hard
-
-"viteshot@npm:0.3.1":
-  version: 0.3.1
-  resolution: "viteshot@npm:0.3.1"
-  dependencies:
-    "@svgr/core": "npm:^5.5.0"
-    assert-never: "npm:^1.2.1"
-    chalk: "npm:^4.1.2"
-    connect: "npm:^3.7.0"
-    fs-extra: "npm:^10.0.0"
-    get-port: "npm:^5.1.1"
-    glob: "npm:^7.1.7"
-    rollup-plugin-friendly-type-imports: "npm:^1.0.1"
-    simple-git: "npm:^2.44.0"
-    vite: "npm:^2.5.1"
-    vite-tsconfig-paths: "npm:^3.3.13"
-    yargs: "npm:^17.1.1"
-  peerDependencies:
-    "@percy/puppeteer": ^2.0.0
-    "@sveltejs/vite-plugin-svelte": ^1.0.0
-    "@vitejs/plugin-vue": ^1.2.3
-    puppeteer: ^10.2.0
-    vite-plugin-solid: ^2.0.0
-  peerDependenciesMeta:
-    "@percy/puppeteer":
-      optional: true
-    "@sveltejs/vite-plugin-svelte":
-      optional: true
-    "@vitejs/plugin-vue":
-      optional: true
-    puppeteer:
-      optional: true
-    vite-plugin-solid:
-      optional: true
-  bin:
-    viteshot: lib/cli.js
-  checksum: 0e0343d0224c5dd508446d300643b0514a9a597eda18c7d14de6a1a4cd9ff0a493779b3d79fbb4223d38480920b37c22d9ec9abeb43c674a63a419e47ec613ac
   languageName: node
   linkType: hard
 
@@ -7693,6 +16119,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vm-browserify@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "vm-browserify@npm:1.1.2"
+  checksum: 49a170b02e4fed6675b843c2dfe06424f526f7c09f606af73360e07455876338942a1c1f578d7bcc05f1a496fd7dedfd648733b918bb4492c3e6eac0705c0038
+  languageName: node
+  linkType: hard
+
 "vscode-languageserver-textdocument@npm:^1.0.5":
   version: 1.0.5
   resolution: "vscode-languageserver-textdocument@npm:1.0.5"
@@ -7707,10 +16140,200 @@ __metadata:
   languageName: node
   linkType: hard
 
+"watchpack-chokidar2@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "watchpack-chokidar2@npm:2.0.1"
+  dependencies:
+    chokidar: "npm:^2.1.8"
+  checksum: 7f5b14db23da76ff6098d22e57fe84d73b05494911e20402b405634bf64d0d7d739efa433505ed1553248ac4e00f5eeacda7581bb51d7f7a6271090cfb742c53
+  languageName: node
+  linkType: hard
+
+"watchpack@npm:^1.7.4":
+  version: 1.7.5
+  resolution: "watchpack@npm:1.7.5"
+  dependencies:
+    chokidar: "npm:^3.4.1"
+    graceful-fs: "npm:^4.1.2"
+    neo-async: "npm:^2.5.0"
+    watchpack-chokidar2: "npm:^2.0.1"
+  dependenciesMeta:
+    chokidar:
+      optional: true
+    watchpack-chokidar2:
+      optional: true
+  checksum: c10e43a671f343a2ae7e7aacf413c293ff423495a8b41a4fd01129921b48e842aed9b987775317735bf57da006fbb8365d0a6ebe967a2444bfe6fbadb0f50867
+  languageName: node
+  linkType: hard
+
+"watchpack@npm:^2.2.0, watchpack@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "watchpack@npm:2.4.0"
+  dependencies:
+    glob-to-regexp: "npm:^0.4.1"
+    graceful-fs: "npm:^4.1.2"
+  checksum: f5fd095d2b5b201e2f70c74d3ea187e3b679aaf0a871b8df5390bc9c7eff61c0d80b34a058293bdc4e2ac1b8689fa7d2df1c42aae4001aecd416c6d1d2271705
+  languageName: node
+  linkType: hard
+
+"web-namespaces@npm:^1.0.0":
+  version: 1.1.4
+  resolution: "web-namespaces@npm:1.1.4"
+  checksum: b6ad2d36ca9c1320b2debe7b917dd7c24eec42a58b32d91a4f5845f3a28f63d85f93f483e49685704600db34cf3a33d846564d910e186687269c2a77a3344b5c
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^3.0.0":
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
   checksum: 57c8c5fdd986be5432ea6adacd87d6757144289d3b48b33441e7310bd4f4f6d782dd34acbd74d61e923c142cc50333d27ba58235692fa7248541c0bcce2563e1
+  languageName: node
+  linkType: hard
+
+"webpack-dev-middleware@npm:^3.7.3":
+  version: 3.7.3
+  resolution: "webpack-dev-middleware@npm:3.7.3"
+  dependencies:
+    memory-fs: "npm:^0.4.1"
+    mime: "npm:^2.4.4"
+    mkdirp: "npm:^0.5.1"
+    range-parser: "npm:^1.2.1"
+    webpack-log: "npm:^2.0.0"
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 97c7b1477db837fc9e554a4f3bd079f2e4522a40156771d231172ea7010d88e71f32bcb0e8332757f2369d92fd44af8c1322da0185a102807d9a27390e80881f
+  languageName: node
+  linkType: hard
+
+"webpack-filter-warnings-plugin@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "webpack-filter-warnings-plugin@npm:1.2.1"
+  peerDependencies:
+    webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
+  checksum: 933bdbc35b7f5fa3064505f3f07c4cd9fad95a4bca25b54d60bd722fc0cbdea035b7bad72fa590f98323833ebfb3b3db706daa4a5dab05fd3628879c1ff41d68
+  languageName: node
+  linkType: hard
+
+"webpack-hot-middleware@npm:^2.25.1":
+  version: 2.25.1
+  resolution: "webpack-hot-middleware@npm:2.25.1"
+  dependencies:
+    ansi-html-community: "npm:0.0.8"
+    html-entities: "npm:^2.1.0"
+    querystring: "npm:^0.2.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 34750241f4a4e050819ab528c80cf5d8e4171ea2c2315ea4599e61941321d6a3b511d1b2fd86b83cfd75320e5f9ad45a5b733dbb73b3b1b6ab85872078a124f1
+  languageName: node
+  linkType: hard
+
+"webpack-log@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "webpack-log@npm:2.0.0"
+  dependencies:
+    ansi-colors: "npm:^3.0.0"
+    uuid: "npm:^3.3.2"
+  checksum: 3926b8a05f45a1929ba75ceeace2ce48fb0ea9a26970f01a769a33aa98293435035d75587f8bdd3f5a34c4e8f5792235e464b23c3d9514c5a0eba55ccbca1cd3
+  languageName: node
+  linkType: hard
+
+"webpack-sources@npm:^1.4.0, webpack-sources@npm:^1.4.1, webpack-sources@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "webpack-sources@npm:1.4.3"
+  dependencies:
+    source-list-map: "npm:^2.0.0"
+    source-map: "npm:~0.6.1"
+  checksum: 1119600f0fa6e0e7b3e12804d93401dd87011fa38ee10ae05988fb200a82166687116f13415934424f4372f6431955a1725ecb48fc06f2e77d0c380542c5e72a
+  languageName: node
+  linkType: hard
+
+"webpack-sources@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "webpack-sources@npm:3.2.3"
+  checksum: aaccb99ee23afcfa1ebddbd7101f7cf15cdc3d72afe37258cf6d852eb6cfedf540086fae3a53b2c65412040eb2e1a3e7b1bff077b09eaf4f82f032a8211d6a6f
+  languageName: node
+  linkType: hard
+
+"webpack-virtual-modules@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "webpack-virtual-modules@npm:0.2.2"
+  dependencies:
+    debug: "npm:^3.0.0"
+  checksum: 3ef8fab8ce838b1bf3cb3b1850fa8e0afc55db8d56b11ca59e0f77d31bfca74bdaddd57d5e21609cb3a768757af4660bd9bb413976cd3cd9602b05d39a855db7
+  languageName: node
+  linkType: hard
+
+"webpack@npm:4":
+  version: 4.46.0
+  resolution: "webpack@npm:4.46.0"
+  dependencies:
+    "@webassemblyjs/ast": "npm:1.9.0"
+    "@webassemblyjs/helper-module-context": "npm:1.9.0"
+    "@webassemblyjs/wasm-edit": "npm:1.9.0"
+    "@webassemblyjs/wasm-parser": "npm:1.9.0"
+    acorn: "npm:^6.4.1"
+    ajv: "npm:^6.10.2"
+    ajv-keywords: "npm:^3.4.1"
+    chrome-trace-event: "npm:^1.0.2"
+    enhanced-resolve: "npm:^4.5.0"
+    eslint-scope: "npm:^4.0.3"
+    json-parse-better-errors: "npm:^1.0.2"
+    loader-runner: "npm:^2.4.0"
+    loader-utils: "npm:^1.2.3"
+    memory-fs: "npm:^0.4.1"
+    micromatch: "npm:^3.1.10"
+    mkdirp: "npm:^0.5.3"
+    neo-async: "npm:^2.6.1"
+    node-libs-browser: "npm:^2.2.1"
+    schema-utils: "npm:^1.0.0"
+    tapable: "npm:^1.1.3"
+    terser-webpack-plugin: "npm:^1.4.3"
+    watchpack: "npm:^1.7.4"
+    webpack-sources: "npm:^1.4.1"
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+    webpack-command:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: bcdb463e682bc410328725940a5fb63da2adb6c5e65903ffd543c48afb643c00285fdc923a8a98ba2451a131f566e2aeba2fb120cbc616ca4b25bfbe92a19e42
+  languageName: node
+  linkType: hard
+
+"webpack@npm:>=4.43.0 <6.0.0":
+  version: 5.74.0
+  resolution: "webpack@npm:5.74.0"
+  dependencies:
+    "@types/eslint-scope": "npm:^3.7.3"
+    "@types/estree": "npm:^0.0.51"
+    "@webassemblyjs/ast": "npm:1.11.1"
+    "@webassemblyjs/wasm-edit": "npm:1.11.1"
+    "@webassemblyjs/wasm-parser": "npm:1.11.1"
+    acorn: "npm:^8.7.1"
+    acorn-import-assertions: "npm:^1.7.6"
+    browserslist: "npm:^4.14.5"
+    chrome-trace-event: "npm:^1.0.2"
+    enhanced-resolve: "npm:^5.10.0"
+    es-module-lexer: "npm:^0.9.0"
+    eslint-scope: "npm:5.1.1"
+    events: "npm:^3.2.0"
+    glob-to-regexp: "npm:^0.4.1"
+    graceful-fs: "npm:^4.2.9"
+    json-parse-even-better-errors: "npm:^2.3.1"
+    loader-runner: "npm:^4.2.0"
+    mime-types: "npm:^2.1.27"
+    neo-async: "npm:^2.6.2"
+    schema-utils: "npm:^3.1.0"
+    tapable: "npm:^2.1.1"
+    terser-webpack-plugin: "npm:^5.1.3"
+    watchpack: "npm:^2.4.0"
+    webpack-sources: "npm:^3.2.3"
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: d6416e650775ec1ac2087daa1f0db738a07bd709b1ab2784d902d4add2d75bdbfa1c6103ce1191ddc11aaa08ad99cc99c49bfcf885a4b89553286716c3c1a9b4
   languageName: node
   linkType: hard
 
@@ -7748,7 +16371,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:^1.1.5":
+"wide-align@npm:^1.1.2, wide-align@npm:^1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
   dependencies:
@@ -7757,10 +16380,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"word-wrap@npm:^1.2.3":
+"widest-line@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "widest-line@npm:3.1.0"
+  dependencies:
+    string-width: "npm:^4.0.0"
+  checksum: a82a38cdd25daa8f242e4731b72824c12d1eebcaaaae7611787d383004013893969a6cfbe68fc27cb46d486210d35948174daa11c0430115266b94aead6b0160
+  languageName: node
+  linkType: hard
+
+"word-wrap@npm:^1.2.3, word-wrap@npm:~1.2.3":
   version: 1.2.3
   resolution: "word-wrap@npm:1.2.3"
   checksum: 17267cdb6baa9d5452b0998531adafd2df52a25159f27cbb754b2fdcff4af8808019efe4c0a2bcc5ceb63becb30df07c792c0125ad21991266aefadb940df74a
+  languageName: node
+  linkType: hard
+
+"wordwrap@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "wordwrap@npm:1.0.0"
+  checksum: 259c00501f75c002e3990eb11c7721bb8a0b039341eaf3a3be9169d6c35cf7c35ba2e942ae76f06a92af63f22495db72ebc586b1d8f7f2e86db942f664e9e820
+  languageName: node
+  linkType: hard
+
+"worker-farm@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "worker-farm@npm:1.7.0"
+  dependencies:
+    errno: "npm:~0.1.7"
+  checksum: 21f7c38e2ff02ffe637783b552b1d7c93aa31c6fad9cde7f7e376cb0716f144f4237942f0377c155d8017aeb119e71f6843607e96f37c3d47326859d692665fc
+  languageName: node
+  linkType: hard
+
+"worker-rpc@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "worker-rpc@npm:0.1.1"
+  dependencies:
+    microevent.ts: "npm:~0.1.1"
+  checksum: 906e8586e3616eee42338c30c966ec2abe8bf7b0263a98071711dd1211c071bfa963d3b7ed429ad7d86c9e814ab50adf7605c9b789303d4f0d0a64781157b418
   languageName: node
   linkType: hard
 
@@ -7805,6 +16462,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:^8.2.3":
+  version: 8.8.1
+  resolution: "ws@npm:8.8.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 807217fa26495f179b03c1160bacaee829234b66f4d22b6df00dc335268e92b537add73edb84046827aadd858c997213d1c78743c571339fe25cc6d51d3e5dea
+  languageName: node
+  linkType: hard
+
+"x-default-browser@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "x-default-browser@npm:0.4.0"
+  dependencies:
+    default-browser-id: "npm:^1.0.4"
+  dependenciesMeta:
+    default-browser-id:
+      optional: true
+  bin:
+    x-default-browser: bin/x-default-browser.js
+  checksum: 0b83828fb9607d4fa137bb58a4b4c1758a4b4171241c57df521e6d9028271b3f9e482786d20ba2f2a9a990b9ffa691f8e2b3435d1d7e2ebee6a86f9836df77bd
+  languageName: node
+  linkType: hard
+
 "xdg-basedir@npm:^4.0.0":
   version: 4.0.0
   resolution: "xdg-basedir@npm:4.0.0"
@@ -7824,10 +16510,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xtend@npm:^4.0.0, xtend@npm:^4.0.1, xtend@npm:~4.0.1":
+  version: 4.0.2
+  resolution: "xtend@npm:4.0.2"
+  checksum: 3d5d245e44d76b4eaf8a357199541347da8ce522bc0573fdb89b01ff6594b33364569d1dba02ccfe3ee86b384c0d61c06fda1b0cff71f382029e2a18e2f592f7
+  languageName: node
+  linkType: hard
+
+"y18n@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "y18n@npm:4.0.3"
+  checksum: 7c4476daacd12a81be7a0d0373ca73da750ec1d02907c85654b5d22f09108c40b8291da12b73b254bd8ed113a21d2b5bd8ec15605e213ac653ca922a139c257a
+  languageName: node
+  linkType: hard
+
 "y18n@npm:^5.0.5":
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 10a6a4dcab8518b72a500520664b686bffe79d8e756af1a7eedf49fa72ab35e40f508896e0baa534f7f92e08193a6dad4283298c11ea7885e710c76b7e2bcc7a
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^3.0.2":
+  version: 3.1.1
+  resolution: "yallist@npm:3.1.1"
+  checksum: 8d382abef6365eb6800ef86a429e8a78347089b7867cdb7ae146e5f3629baebe41967b9d7715ae22c9514659a2855a10e104d68441e339f5060b286b2f3e11c6
   languageName: node
   linkType: hard
 
@@ -7838,7 +16545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml-eslint-parser@npm:1.0.1, yaml-eslint-parser@npm:^1.0.0":
+"yaml-eslint-parser@npm:1.0.1":
   version: 1.0.1
   resolution: "yaml-eslint-parser@npm:1.0.1"
   dependencies:
@@ -7849,7 +16556,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^1.10.0":
+"yaml-eslint-parser@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "yaml-eslint-parser@npm:1.1.0"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    yaml: "npm:^2.0.0"
+  checksum: fe75aed4d2c3d3e162faa6fef2168b04c97f2da58bb7cb6ea2f9493e828d9dfcc8bc1a0eebcbe414db400d545a4ba039c2a1514f5e6afba27f65269641e1775c
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^1.10.0, yaml@npm:^1.7.2":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: d6f04384bdf1105256581aef39991f825e358f3f48f081974b0e0f39ff5240c60ccafb5842cb79d1287517efa2b9ee172c702f2e4855ba6cc46948b40a43aa6e
@@ -7863,7 +16581,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.3, yargs-parser@npm:^20.2.9":
+"yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3, yargs-parser@npm:^20.2.9":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: fd739a429b7cde755b8e9d28520619fb8adb94c686b2d75d3c93a6ec199fbc8bf120af6d2be144f8d3075f3d675b09893f8894a362548107aa90bb97ad662c7a
@@ -7877,7 +16595,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.0.0, yargs@npm:^17.1.1":
+"yargs@npm:^16.2.0":
+  version: 16.2.0
+  resolution: "yargs@npm:16.2.0"
+  dependencies:
+    cliui: "npm:^7.0.2"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.0"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^20.2.2"
+  checksum: be4564db8f818c7eeda96653331a62829522ab2a8a773da079ebf3870ab5b875177c397c57f06d6c9238d613567ebe69d4cbac35dbef1cc9928183df7ba8d479
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.0.0":
   version: 17.5.1
   resolution: "yargs@npm:17.5.1"
   dependencies:
@@ -7903,5 +16636,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 63eceacd482622afd71290541a9823a0e5eed88a6b58a5d136a5fb8151ed4d1549c80f28d74d4ad351582f9890635d49e6cf70f8d3cc64948640f839f6a37c70
+  languageName: node
+  linkType: hard
+
+"zwitch@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "zwitch@npm:1.0.5"
+  checksum: 47a33f9d7e009662a71cc07a5e8fc742c6fae5aaa0a086b58ea21d933e43b305d36c90b5acc5e8efbc55afd51d44627a31e83360540ba6395b500e8987051181
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

### :sparkles: Features

- `Options?.sourcemap`

  Allows users to pass [custom sourcemap options][1] (`Omit<SourceMapOptions, 'source'>`), `true` to use plugin defaults, or `false` to disable sourcemap generation. Defaults to `true`.

- `interface PluginReactDocgenTypeScript extends vite.Plugin`

  For the developers like me...aka the anal TypeScript developers 😅💙

- Implemented `PluginReactDocgenTypeScript.transform`

  Parses modules for component docgen info. Build hook [`transform`][2] is called on each module request and can be used to augment individual modules. The hook receives two arguments: the module code to transform (which may already include transforms applied by other plugins), `code`, and the path to the module, `id`.
  
  For successfully parsed and transformed modules, the function will return an updated version of `code` that includes logic to add a `__docgenInfo` property to each component exported from `id`. If `options.sourcemap` is truthy, the function will also return a [version 3 sourcemap][3].
  
  If `id` doesn't meet filtering requirements (set by `options.exclude` and `options.include`), the function will return `undefined`. If `id` does end up being parsed, but doesn't yield any docgen information, `null` will be returned instead.

  ```ts
    /**
     * @param {TransformPluginContext} this - Plugin context
     * @param {string} code - Module code being transformed
     * @param {string} id - Path to module being transformed
     * @return {Promise<TransformResult>} Transform result
     */
    transform(
      this: TransformPluginContext,
      code: string,
      id: string
    ): Promise<TransformResult>
  ```

### :recycle: Code Improvements

- Removed `Options?.name`

  The plugin assumes `doc.displayName` is the component name when setting `__docgenInfo`. The `name` option allows users to generate component names instead (see #1). **This option is not needed because the docgen parser already allows users to generate component display names**:
    
  ```ts
      const resolvedComponentName = componentNameResolver(nameSource, source);
      const { description, tags } = this.findDocComment(commentSource);
      const displayName =
        resolvedComponentName ||
        tags.visibleName ||
        computeComponentName(nameSource, source, customComponentTypes);
  ```
  > [parser.ts@2.2.2#L350-L355][4]
  
  **Users exporting multiple components from `id` should pass `options.componentNameResolver`, use `@visibleName` in JSDoc comments, and/or pass `options.customComponentTypes`**. If using `@visibleName`, `eslint-plugin-jsdoc` users may need to also update their eslint config:

  ```cjs
  /**
   * @file ESLint Configuration
   * @see https://eslint.org/docs/user-guide/configuring
   */

  const { Linter } = require('eslint')

  /**
   * @type {Linter.Config}
   * @const config - ESLint configuration object
   */
  const config = {
    globals: {
      JSX: 'readonly'
    },
    plugins: ['jsdoc'],
    rules: {
      'jsdoc/check-tag-names': [
        1,
        {
          definedTags: ['visibleName'],
          jsxTags: true
        }
      ]
    },
    settings: {
      jsdoc: {
        structuredTags: {
          visibleName: { required: ['name'] }
        }
    }
  }

  module.exports = config
  ```

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

```sh
 RUN  v0.19.1

 ✓ src/__tests__/plugin.spec.ts > unit:plugin > @returns > should return PluginReactDocgenTypeScript
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.apply > should set PluginReactDocgenTypeScript.apply to undefined given [{"apply": undefined}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.apply > should set PluginReactDocgenTypeScript.apply to "build" given [{"apply": "build"}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.apply > should set PluginReactDocgenTypeScript.apply to "serve" given [{"apply": "serve"}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.apply > should set PluginReactDocgenTypeScript.apply to [Function spy] given [{"apply": [Function spy]}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.enforce > should set PluginReactDocgenTypeScript.enforce to "pre" given [{"enforce": undefined}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.enforce > should set PluginReactDocgenTypeScript.enforce to "pre" given [{"enforce": "pre"}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.enforce > should set PluginReactDocgenTypeScript.enforce to "post" given [{"enforce": "post"}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.shouldIncludeExpression > should not throw if ComponentDoc.expression is defined
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.sourcemap > should return Partial<SourceDescription> given [{"sourcemap": undefined}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.sourcemap > should return Partial<SourceDescription> given [{"sourcemap": {"includeContent": true}}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.sourcemap > should return string given [{"sourcemap": false}]
 ✓ src/__tests__/plugin.functional.spec.ts > functional:plugin > should transform module if id matches include pattern
 ✓ src/__tests__/plugin.functional.spec.ts > functional:plugin > should not transform module if id does not match include pattern
 ✓ src/__tests__/plugin.functional.spec.ts > functional:plugin > should not transform module if id matches exclude pattern
 ✓ src/__tests__/plugin.functional.spec.ts > functional:plugin > should not transform module if docgen info is missing

Test Files  2 passed (2)
     Tests  16 passed (16)
      Time  14.83s (in thread 12.37s, 119.88%)

-----------|---------|----------|---------|---------|-------------------
File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------|---------|----------|---------|---------|-------------------
All files  |     100 |      100 |     100 |     100 |                   
 plugin.ts |     100 |      100 |     100 |     100 |                   
-----------|---------|----------|---------|---------|-------------------
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

- https://github.com/styleguidist/react-docgen-typescript/pull/441

  This PR will allow users exporting multiple components to forego passing `options.componentNameResolver`, using `@visibleName` in JSDoc comments,  and/or passing `options.customComponentTypes`:
    
  ```ts
  /**
   * Ensure the .displayName is for the currently processing function.
   *
   * This avoids the following situations:
   *
   *  - A file has multiple functions, one has `.displayName`, and all
   *    functions ends up with that same `.displayName` value.
   *
   *  - A file has multiple functions, each with a different
   *    `.displayName`, but the first is applied to all of them.
   */
  const flowNodeNameEscapedText = (statement as any)?.flowNode?.node?.name
    ?.escapedText as false | ts.__String | undefined
  ```

  > https://github.com/styleguidist/react-docgen-typescript/pull/441/commits/0dc05e522db647320fc99a33d4a402685910a220

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

closes #2 

## Submission checklist

- [x] pr title prefixed with `PR:` (e.g: `PR: User authentication`)
- [x] pr title describes functionality (not vague title like `Update index.md`)
- [x] pr targets branch `next`
- [x] project was run locally to verify that there are no errors
- [x] documentation added or updated

[1]: https://github.com/Rich-Harris/magic-string#sgeneratemap-options-
[2]: https://rollupjs.org/guide/en/#transform
[3]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit
[4]: https://github.com/styleguidist/react-docgen-typescript/blob/v2.2.2/src/parser.ts#L350-L355
