### PR TITLE
release: @flex-development/vite-plugin-react-docgen-typescript@1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+## 1.0.0 (2022-08-01)
+
+
+### :sparkles: Features
+
+* **plugin:** docgen parsing ([#4](https://github.com/flex-development/vite-plugin-react-docgen-typescript/issues/4)) ([90af4c8](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/90af4c8fbd895d8885860a63dfbb776427361d5d))
+* **plugin:** options ([#3](https://github.com/flex-development/vite-plugin-react-docgen-typescript/issues/3)) ([93bb026](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/93bb02672f7cfcece00207d4d9e53a7ef6af5628))
+
+
+### :bug: Bug Fixes
+
+* **cjs:** default package export ([5160e1d](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/5160e1dbb365edae236195087cac1b6573ffa0ca))
+* **deps-dev:** command injection in `simple-git` ([c0fdb31](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/c0fdb31208a81de0a7b5db54408bab0ad4840814))
+* **deps-dev:** regular expression denial of service in `glob-parent` ([e152d83](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/e152d83a25cec60991b63f45163507b3b3f9d180))
+* **deps-dev:** regular expression denial of service in `trim` ([9db3278](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/9db3278df1cdc6c05a3cac079565fbeab2106f84))
+* **deps-dev:** uncontrolled resource consumption in `trim-newlines` ([3c64f40](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/3c64f4023ab05d5da1d39ace9f8a5cb745ec35e8))
+
+
+### :package: Build
+
+* **deps-dev:** bump @types/mvdan-sh from 0.5.1 to 0.10.0 ([1a553ec](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/1a553ec84acedd47b0d9636f6964976c585683b7))
+* **deps-dev:** bump @types/node from 16.11.45 to 16.11.46 ([1d92a3b](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/1d92a3b6fb34c6b5bc5b7cd8eb539e4e1aaebe97))
+* **deps-dev:** bump @types/node from 16.11.46 to 16.11.47 ([45000ad](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/45000ad7159951bdf3b7721e41572f11f6a3dc5f))
+* **deps-dev:** bump @types/prettier from 2.6.3 to 2.6.4 ([e282d3d](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/e282d3d1c2b226875625d46be62a591c89ef65e5))
+* **deps-dev:** bump @vitest/ui from 0.19.1 to 0.20.2 ([8008811](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/80088118a81c92cdbd90d669333653eb714b2d11))
+* **deps-dev:** bump cspell from 6.4.1 to 6.5.0 ([5765fdd](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/5765fddd3a4ebe841f4814cbcbb05103f7c4f8d0))
+* **deps-dev:** bump eslint-plugin-jest from 26.6.0 to 26.7.0 ([b2d7581](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/b2d7581ebcdaf91823676bb3111c270ff7e1858d))
+* **deps-dev:** bump eslint-plugin-jsdoc from 39.3.3 to 39.3.4 ([9643afc](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/9643afca71cb4bdf996e9095b797976ddf0d1f91))
+* **deps-dev:** bump eslint-plugin-yml from 1.0.0 to 1.1.0 ([b9ebe3b](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/b9ebe3bef0a8b785f8136d2d4883387e07f65e1f))
+* **deps-dev:** bump prettier-plugin-sh from 0.12.6 to 0.12.8 ([370954d](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/370954da5fa93101c9ee954f892e224466af31de))
+* **deps-dev:** bump resolve-tspaths from 0.7.1 to 0.7.4 ([fc26382](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/fc26382d0da3159cd715e09e8661d2b410d9c826))
+* **deps-dev:** bump vite from 3.0.3 to 3.0.4 ([af60fdb](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/af60fdb192c0789e2668bd8c2ca0c90121b1d7da))
+* **deps-dev:** bump vitest from 0.19.1 to 0.20.2 ([20a341c](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/20a341c5af8811e7c4f88da9df3b1e48bbbe82bd))
+* **deps-dev:** bump yaml-eslint-parser from 1.0.1 to 1.1.0 ([3c54b79](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/3c54b793348d7d251d29f41ebe86e4b1a21a084b))
+
+
+### :pencil: Documentation
+
+* install from git ([63529b3](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/63529b35876554de24a337b66dfefb2f0fce8f2e))
+* reword release branch naming conventions note ([604a3a0](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/604a3a048f633ca887805b6d0d6e24430d1ae2b2))
+* update branching model, pull requests, and releasing ([ecc9b48](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/ecc9b486c5f201391aec3eb8ee4d26f183280b3d))
+* usage ([f60f61b](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/f60f61b3636eaa174d509889f5892dcbbb582505))
+
+
+### :robot: Continuous Integration
+
+* **deps:** bump actions/checkout from 2 to 3 ([#5](https://github.com/flex-development/vite-plugin-react-docgen-typescript/issues/5)) ([c93048d](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/c93048d609da695e94ddf305e941bbb7e6191a54))
+* **deps:** bump actions/setup-node from 2 to 3 ([#6](https://github.com/flex-development/vite-plugin-react-docgen-typescript/issues/6)) ([50e3a39](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/50e3a395e21aa29d24491633e4dd1d7de7508a5f))
+* **deps:** bump ahmadnassri/action-dependabot-auto-merge from 2.4.0 to 2.6.0 ([9a1e95f](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/9a1e95fc801710bb2c3f281ac0cb85c1f163dfc9))
+* **deps:** bump dessant/lock-threads from 2 to 3 ([#8](https://github.com/flex-development/vite-plugin-react-docgen-typescript/issues/8)) ([11ea8d6](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/11ea8d68df209c86ffd41b4fd3c970fdcea4d5f6))
+* **workflows:** `continuous-deployment` ([c30a018](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/c30a0188ecc4ffb60c63dadc47514df08bf29432))
+* **workflows:** allow all `dependabot-auto-merge` update types ([58f0340](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/58f03408f4e2bda758e44cf253a008d4787f4cb0))
+* **workflows:** cleanup docs ([7cbf5b1](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/7cbf5b14bb37d4111e193686d6bc42bb59712a51))
+* **workflows:** fix [@dependabot](https://github.com/dependabot) permissions in ci workflow ([f98886a](https://github.com/flex-development/vite-plugin-react-docgen-typescript/commit/f98886a27a0b5639bd3175f386a89c0264dc4f56))
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/vite-plugin-react-docgen-typescript",
   "description": "A react-docgen-typescript plugin for Vite",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "keywords": [
     "docgen",
     "react",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- Bumped version to `1.0.0`
- Updated `CHANGELOG.md`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

```zsh
 RUN  v0.20.2

 ✓ src/__tests__/plugin.spec.ts > unit:plugin > @returns > should return PluginReactDocgenTypeScript
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.apply > should set PluginReactDocgenTypeScript.apply to undefined given [{"apply": undefined}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.apply > should set PluginReactDocgenTypeScript.apply to "build" given [{"apply": "build"}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.apply > should set PluginReactDocgenTypeScript.apply to "serve" given [{"apply": "serve"}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.apply > should set PluginReactDocgenTypeScript.apply to [Function spy] given [{"apply": [Function spy]}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.enforce > should set PluginReactDocgenTypeScript.enforce to "pre" given [{"enforce": undefined}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.enforce > should set PluginReactDocgenTypeScript.enforce to "pre" given [{"enforce": "pre"}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.enforce > should set PluginReactDocgenTypeScript.enforce to "post" given [{"enforce": "post"}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.shouldIncludeExpression > should not throw if ComponentDoc.expression is defined
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.sourcemap > should return Partial<SourceDescription> given [{"sourcemap": undefined}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.sourcemap > should return Partial<SourceDescription> given [{"sourcemap": {"includeContent": true}}]
 ✓ src/__tests__/plugin.spec.ts > unit:plugin > options > options?.sourcemap > should return string given [{"sourcemap": false}]
 ✓ src/__tests__/plugin.functional.spec.ts > functional:plugin > should transform module if id matches include pattern
 ✓ src/__tests__/plugin.functional.spec.ts > functional:plugin > should not transform module if id does not match include pattern
 ✓ src/__tests__/plugin.functional.spec.ts > functional:plugin > should not transform module if id matches exclude pattern
 ✓ src/__tests__/plugin.functional.spec.ts > functional:plugin > should not transform module if docgen info is missing

Test Files  2 passed (2)
     Tests  16 passed (16)
      Time  14.44s (setup 319ms, collect 628ms, tests 12.02s)

-----------|---------|----------|---------|---------|-------------------
File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------|---------|----------|---------|---------|-------------------
All files  |     100 |      100 |     100 |     100 |                   
 plugin.ts |     100 |      100 |     100 |     100 |                   
-----------|---------|----------|---------|---------|-------------------
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

- releases #3
- releases #4

## Submission checklist

- [x] [pr naming conventions][1]
- [x] project was run locally to verify that there are no errors
- [x] documentation added or updated

[1]: https://github.com/flex-development/vite-plugin-react-docgen-typescript/blob/main/CONTRIBUTING.md#pull-request-titles

